### PR TITLE
Implement formula removal and add tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,7 +89,7 @@ target_link_libraries(web_interface PRIVATE m pthread)
 # Simple tests
 add_executable(test_arithmetic tests/test_arithmetic.c src/arithmetic.c)
 target_link_libraries(test_arithmetic PRIVATE m)
-add_executable(test_rule_engine tests/test_rule_engine.c src/rule_engine.c src/embed.c)
+add_executable(test_rule_engine tests/test_rule_engine.c src/rule_engine.c src/embed.c src/formula.c)
 target_link_libraries(test_rule_engine PRIVATE ${JSONC_LIBRARIES} m)
 
 # Добавляем пути к заголовочным файлам для веб-интерфейса

--- a/include/formula.h
+++ b/include/formula.h
@@ -35,5 +35,6 @@ double evaluate_formula(const char* formula, double x);
 double evaluate_effectiveness(const Formula* formula);
 int validate_formula(const Formula* formula);
 int get_formula_type(const char* content);
+void formula_collection_remove(FormulaCollection* collection, const char* id);
 
 #endif // FORMULA_H

--- a/src/formula.c
+++ b/src/formula.c
@@ -62,13 +62,31 @@ int formula_collection_add(FormulaCollection* collection, const Formula* formula
 // Поиск формулы по ID
 Formula* formula_collection_find(FormulaCollection* collection, const char* id) {
     if (!collection || !id) return NULL;
-    
+
     for (size_t i = 0; i < collection->count; i++) {
         if (strcmp(collection->formulas[i].id, id) == 0) {
             return &collection->formulas[i];
         }
     }
     return NULL;
+}
+
+void formula_collection_remove(FormulaCollection* collection, const char* id) {
+    if (!collection || !id) return;
+
+    for (size_t i = 0; i < collection->count; i++) {
+        if (strcmp(collection->formulas[i].id, id) == 0) {
+            if (i + 1 < collection->count) {
+                memmove(&collection->formulas[i],
+                        &collection->formulas[i + 1],
+                        (collection->count - i - 1) * sizeof(Formula));
+            }
+            if (collection->count > 0) {
+                collection->count--;
+            }
+            return;
+        }
+    }
 }
 
 // Распознавание типа формулы
@@ -341,4 +359,5 @@ void example_dynamic_complexity() {
     iteration++;
     int dynamic_complexity = calculate_dynamic_complexity(FORMULA_TYPE_SIMPLE, iteration);
     // ...дальнейшая обработка dynamic_complexity...
+    (void)dynamic_complexity;
 }

--- a/src/rule_engine.c
+++ b/src/rule_engine.c
@@ -253,7 +253,7 @@ int rule_engine_sync(RuleEngine *re, const char *cluster_path) {
     size_t n = json_object_array_length(cluster);
     for (size_t i = 0; i < n; ++i) {
         json_object *r = json_object_array_get_idx(cluster, i);
-        json_object *jexpr = NULL, *jid = NULL;
+        json_object *jexpr = NULL;
         if (!json_object_object_get_ex(r, "expr", &jexpr)) continue;
         const char *expr = json_object_get_string(jexpr);
         // check if expr exists in local rules

--- a/tests/test_rule_engine.c
+++ b/tests/test_rule_engine.c
@@ -1,8 +1,68 @@
 #include <stdio.h>
 #include <json-c/json.h>
+#include <string.h>
 #include "../src/rule_engine.h"
+#include "../src/formula.h"
+
+static int test_formula_collection_remove(void) {
+    FormulaCollection *collection = formula_collection_create(2);
+    if (!collection) {
+        printf("FAIL: unable to create collection\n");
+        return 1;
+    }
+
+    Formula f1 = {0};
+    Formula f2 = {0};
+    Formula f3 = {0};
+
+    snprintf(f1.id, sizeof(f1.id), "id-1");
+    snprintf(f2.id, sizeof(f2.id), "id-2");
+    snprintf(f3.id, sizeof(f3.id), "id-3");
+
+    snprintf(f1.content, sizeof(f1.content), "f(x) = x");
+    snprintf(f2.content, sizeof(f2.content), "f(x) = 2 * x");
+    snprintf(f3.content, sizeof(f3.content), "f(x) = 3 * x");
+
+    if (formula_collection_add(collection, &f1) != 0 ||
+        formula_collection_add(collection, &f2) != 0 ||
+        formula_collection_add(collection, &f3) != 0) {
+        printf("FAIL: unable to add formulas\n");
+        formula_collection_destroy(collection);
+        return 1;
+    }
+
+    if (collection->count != 3) {
+        printf("FAIL: unexpected formula count after add: %zu\n", collection->count);
+        formula_collection_destroy(collection);
+        return 1;
+    }
+
+    formula_collection_remove(collection, "id-2");
+
+    if (collection->count != 2) {
+        printf("FAIL: unexpected formula count after remove: %zu\n", collection->count);
+        formula_collection_destroy(collection);
+        return 1;
+    }
+
+    if (strcmp(collection->formulas[0].id, "id-1") != 0 ||
+        strcmp(collection->formulas[1].id, "id-3") != 0) {
+        printf("FAIL: formulas not shifted correctly after remove: [%s, %s]\n",
+               collection->formulas[0].id,
+               collection->formulas[1].id);
+        formula_collection_destroy(collection);
+        return 1;
+    }
+
+    formula_collection_destroy(collection);
+    return 0;
+}
 
 int main(void) {
+    if (test_formula_collection_remove() != 0) {
+        return 1;
+    }
+
     RuleEngine re;
     rule_engine_init(&re, "test_node");
     // ensure list returns array


### PR DESCRIPTION
## Summary
- implement formula_collection_remove to compact the array when deleting by id
- expose the removal helper and include formula.c in the test_rule_engine target
- extend the rule engine test to cover removing a formula and fix minor build warnings

## Testing
- cmake --build cmake-build --target test_rule_engine
- ./cmake-build/test_rule_engine

------
https://chatgpt.com/codex/tasks/task_e_68d28d7b05f88323a4a0d839e3fc2a01