### PR TITLE
Refactor decimal cell tree structure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,8 @@ add_executable(test_rule_engine tests/test_rule_engine.c src/rule_engine.c src/e
 target_link_libraries(test_rule_engine PRIVATE ${JSONC_LIBRARIES} m)
 add_executable(test_formula tests/test_formula.c src/formula.c src/formula_advanced.c src/decimal_cell.c)
 target_link_libraries(test_formula PRIVATE ${JSONC_LIBRARIES} uuid m)
+add_executable(test_decimal_cell tests/test_decimal_cell.c src/kolibri_decimal_cell.c)
+target_link_libraries(test_decimal_cell PRIVATE m)
 target_include_directories(test_formula PRIVATE
         ${CMAKE_SOURCE_DIR}/src
         ${CMAKE_SOURCE_DIR}/include

--- a/src/kolibri_decimal_cell.c
+++ b/src/kolibri_decimal_cell.c
@@ -1,98 +1,390 @@
+#include <ctype.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
+
 #include "kolibri_decimal_cell.h"
 #include "kolibri_ping.h"
 
+static decimal_cell_t* create_child(decimal_cell_t* parent, uint8_t digit) {
+    decimal_cell_t* child = (decimal_cell_t*)calloc(1, sizeof(decimal_cell_t));
+    if (!child) {
+        return NULL;
+    }
+    uint64_t now = now_ms();
+    child->digit = digit % DECIMAL_CELL_FANOUT;
+    child->depth = parent ? (uint8_t)(parent->depth + 1) : 0;
+    child->is_active = true;
+    child->created_at = now;
+    child->last_state_change = now;
+    child->last_sync_time = now;
+    child->sync_interval = parent ? parent->sync_interval : SYNC_INTERVAL;
+    child->parent = parent;
+    for (int i = 0; i < DECIMAL_CELL_FANOUT; i++) {
+        child->children[i] = NULL;
+        child->child_active[i] = false;
+        child->child_last_sync[i] = now;
+        child->child_last_state_change[i] = now;
+    }
+    return child;
+}
+
+static void free_subtree(decimal_cell_t* node) {
+    if (!node) return;
+    for (int i = 0; i < DECIMAL_CELL_FANOUT; i++) {
+        if (node->children[i]) {
+            free_subtree(node->children[i]);
+            node->children[i] = NULL;
+        }
+    }
+    free(node);
+}
+
+static bool node_has_children(const decimal_cell_t* node) {
+    if (!node) return false;
+    for (uint8_t d = 0; d < DECIMAL_CELL_FANOUT; d++) {
+        if (node->children[d]) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static bool deactivate_recursive(decimal_cell_t* node,
+                                 const uint8_t* path,
+                                 size_t path_len,
+                                 uint64_t timestamp) {
+    if (!node) return false;
+    if (path_len == 0) {
+        for (uint8_t d = 0; d < DECIMAL_CELL_FANOUT; d++) {
+            if (node->children[d]) {
+                free_subtree(node->children[d]);
+                node->children[d] = NULL;
+            }
+            node->child_active[d] = false;
+            node->child_last_sync[d] = timestamp;
+            node->child_last_state_change[d] = timestamp;
+        }
+        node->is_active = false;
+        node->last_state_change = timestamp;
+        node->last_sync_time = timestamp;
+        return true;
+    }
+
+    uint8_t digit = path[0] % DECIMAL_CELL_FANOUT;
+    decimal_cell_t* child = node->children[digit];
+    if (!child) {
+        return false;
+    }
+
+    bool remove_child = false;
+    if (path_len == 1) {
+        free_subtree(child);
+        remove_child = true;
+    } else {
+        if (deactivate_recursive(child, path + 1, path_len - 1, timestamp)) {
+            free(child);
+            remove_child = true;
+        }
+    }
+
+    if (remove_child) {
+        node->children[digit] = NULL;
+    }
+    node->child_active[digit] = false;
+    node->child_last_sync[digit] = timestamp;
+    node->child_last_state_change[digit] = timestamp;
+
+    if (remove_child) {
+        if (!node->is_active && !node_has_children(node)) {
+            node->last_state_change = timestamp;
+            return true;
+        }
+    }
+    return false;
+}
+
+static size_t append_fmt(char* buffer, size_t size, size_t used, const char* fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+    va_list ap_copy;
+    va_copy(ap_copy, ap);
+    int needed = vsnprintf(NULL, 0, fmt, ap_copy);
+    va_end(ap_copy);
+    if (needed < 0) {
+        va_end(ap);
+        return used;
+    }
+    if (used < size) {
+        size_t space = size - used;
+        if (space == 0) {
+            // nothing to write but still consume the formatted length
+        } else {
+            vsnprintf(buffer + used, space, fmt, ap);
+        }
+    }
+    va_end(ap);
+    return used + (size_t)needed;
+}
+
+static size_t serialize_node_internal(const decimal_cell_t* node,
+                                      char* buffer,
+                                      size_t size,
+                                      size_t used) {
+    if (!node) return used;
+    used = append_fmt(buffer, size, used,
+                      "{\"digit\":%u,\"depth\":%u,\"active\":%s",
+                      node->digit,
+                      node->depth,
+                      node->is_active ? "true" : "false");
+    bool has_child = false;
+    for (uint8_t d = 0; d < DECIMAL_CELL_FANOUT; d++) {
+        decimal_cell_t* child = node->children[d];
+        if (!child) continue;
+        if (!has_child) {
+            used = append_fmt(buffer, size, used, ",\"children\":[");
+            has_child = true;
+        } else {
+            used = append_fmt(buffer, size, used, ",");
+        }
+        used = append_fmt(buffer, size, used,
+                          "{\"edge_digit\":%u,\"edge_active\":%s,\"node\":",
+                          d,
+                          node->child_active[d] ? "true" : "false");
+        used = serialize_node_internal(child, buffer, size, used);
+        used = append_fmt(buffer, size, used, "}");
+    }
+    if (has_child) {
+        used = append_fmt(buffer, size, used, "]");
+    }
+    used = append_fmt(buffer, size, used, "}");
+    return used;
+}
+
 void init_decimal_cell(decimal_cell_t* cell, uint8_t digit) {
-    if (digit > 9) digit = digit % 10;
-    cell->node_digit = digit;
-    cell->n_neighbors = 0;
-    memset(cell->neighbor_digits, 0, sizeof(cell->neighbor_digits));
-    memset(cell->last_sync, 0, sizeof(cell->last_sync));
-    memset(cell->is_active, 0, sizeof(cell->is_active));
+    if (!cell) return;
+    uint64_t now = now_ms();
+    memset(cell, 0, sizeof(*cell));
+    cell->digit = digit % DECIMAL_CELL_FANOUT;
+    cell->depth = 0;
+    cell->is_active = true;
+    cell->created_at = now;
+    cell->last_state_change = now;
+    cell->last_sync_time = now;
+    cell->sync_interval = SYNC_INTERVAL;
+    cell->parent = NULL;
+    for (int i = 0; i < DECIMAL_CELL_FANOUT; i++) {
+        cell->children[i] = NULL;
+        cell->child_active[i] = false;
+        cell->child_last_sync[i] = now;
+        cell->child_last_state_change[i] = now;
+    }
 }
 
 void cleanup_decimal_cell(decimal_cell_t* cell) {
-    if (cell) {
-        cell->node_digit = 0;
-        cell->n_neighbors = 0;
-        memset(cell->neighbor_digits, 0, sizeof(cell->neighbor_digits));
-        memset(cell->last_sync, 0, sizeof(cell->last_sync));
-        memset(cell->is_active, 0, sizeof(cell->is_active));
-    }
-}
-
-int add_neighbor(decimal_cell_t* cell, uint8_t digit) {
-    if (digit > 9) digit = digit % 10;
-    if (digit == cell->node_digit) return -1;  // нельзя добавить себя как соседа
-    
-    // Проверяем, нет ли уже такого соседа
-    for (int i = 0; i < cell->n_neighbors; i++) {
-        if (cell->neighbor_digits[i] == digit) {
-            return i;  // сосед уже существует
+    if (!cell) return;
+    for (int i = 0; i < DECIMAL_CELL_FANOUT; i++) {
+        if (cell->children[i]) {
+            free_subtree(cell->children[i]);
+            cell->children[i] = NULL;
         }
+        cell->child_active[i] = false;
+        cell->child_last_sync[i] = 0;
+        cell->child_last_state_change[i] = 0;
     }
-    
-    if (cell->n_neighbors >= MAX_NEIGHBORS) return -1;
-    
-    int idx = cell->n_neighbors;
-    cell->neighbor_digits[idx] = digit;
-    cell->last_sync[idx] = now_ms();
-    cell->is_active[idx] = true;
-    cell->n_neighbors++;
-    
-    return idx;
+    cell->is_active = false;
+    cell->last_state_change = 0;
+    cell->last_sync_time = 0;
 }
 
-void remove_neighbor(decimal_cell_t* cell, uint8_t digit) {
-    int idx = get_neighbor_index(cell, digit);
-    if (idx < 0) return;
-    
-    // Сдвигаем остальных соседей
-    for (int i = idx; i < cell->n_neighbors - 1; i++) {
-        cell->neighbor_digits[i] = cell->neighbor_digits[i + 1];
-        cell->last_sync[i] = cell->last_sync[i + 1];
-        cell->is_active[i] = cell->is_active[i + 1];
-    }
-    
-    cell->n_neighbors--;
-}
-
-bool needs_sync(decimal_cell_t* cell, uint8_t neighbor_idx) {
-    if (neighbor_idx >= cell->n_neighbors) return false;
-    if (!cell->is_active[neighbor_idx]) return false;
-    
+decimal_cell_t* decimal_cell_add_path(decimal_cell_t* root,
+                                      const uint8_t* path,
+                                      size_t path_len,
+                                      bool activate) {
+    if (!root) return NULL;
+    decimal_cell_t* current = root;
     uint64_t now = now_ms();
-    return (now - cell->last_sync[neighbor_idx]) >= SYNC_INTERVAL;
+    if (path_len == 0) {
+        current->is_active = activate;
+        current->last_state_change = now;
+        current->last_sync_time = now;
+        return current;
+    }
+    for (size_t i = 0; i < path_len; i++) {
+        uint8_t digit = path[i] % DECIMAL_CELL_FANOUT;
+        if (!current->children[digit]) {
+            decimal_cell_t* child = create_child(current, digit);
+            if (!child) {
+                return NULL;
+            }
+            current->children[digit] = child;
+        }
+        current->child_active[digit] = activate;
+        current->child_last_sync[digit] = now;
+        current->child_last_state_change[digit] = now;
+        current->last_sync_time = now;
+        current = current->children[digit];
+        current->is_active = activate;
+        current->last_sync_time = now;
+        current->last_state_change = now;
+    }
+    return current;
 }
 
-void mark_sync(decimal_cell_t* cell, uint8_t neighbor_idx) {
-    if (neighbor_idx >= cell->n_neighbors) return;
-    cell->last_sync[neighbor_idx] = now_ms();
-    cell->is_active[neighbor_idx] = true;
-}
-
-bool is_neighbor_active(decimal_cell_t* cell, uint8_t neighbor_idx) {
-    if (neighbor_idx >= cell->n_neighbors) return false;
-    return cell->is_active[neighbor_idx];
-}
-
-int get_neighbor_index(decimal_cell_t* cell, uint8_t digit) {
-    if (digit > 9) digit = digit % 10;
-    for (int i = 0; i < cell->n_neighbors; i++) {
-        if (cell->neighbor_digits[i] == digit) {
-            return i;
+decimal_cell_t* decimal_cell_add_path_str(decimal_cell_t* root,
+                                          const char* path,
+                                          bool activate) {
+    if (!root || !path) return NULL;
+    size_t len = strlen(path);
+    if (len == 0) {
+        return decimal_cell_add_path(root, NULL, 0, activate);
+    }
+    uint8_t stack_buf[64];
+    uint8_t* digits = stack_buf;
+    bool heap = false;
+    if (len > sizeof(stack_buf)) {
+        digits = (uint8_t*)malloc(len);
+        if (!digits) {
+            return NULL;
+        }
+        heap = true;
+    }
+    size_t count = 0;
+    for (size_t i = 0; i < len; i++) {
+        if (isdigit((unsigned char)path[i])) {
+            digits[count++] = (uint8_t)(path[i] - '0');
         }
     }
-    return -1;
+    decimal_cell_t* node = decimal_cell_add_path(root, digits, count, activate);
+    if (heap) {
+        free(digits);
+    }
+    return node;
 }
 
-void update_cell_state(decimal_cell_t* cell) {
-    uint64_t now = now_ms();
-    
-    // Проверяем активность соседей
-    for (int i = 0; i < cell->n_neighbors; i++) {
-        if (now - cell->last_sync[i] > SYNC_INTERVAL * 3) {
-            cell->is_active[i] = false;
+decimal_cell_t* decimal_cell_find_path(decimal_cell_t* root,
+                                       const uint8_t* path,
+                                       size_t path_len) {
+    if (!root) return NULL;
+    if (path_len == 0) return root;
+    decimal_cell_t* current = root;
+    for (size_t i = 0; i < path_len; i++) {
+        uint8_t digit = path[i] % DECIMAL_CELL_FANOUT;
+        if (!current->children[digit]) {
+            return NULL;
+        }
+        current = current->children[digit];
+    }
+    return current;
+}
+
+decimal_cell_t* decimal_cell_find_path_str(decimal_cell_t* root, const char* path) {
+    if (!root || !path) return NULL;
+    size_t len = strlen(path);
+    if (len == 0) return root;
+    uint8_t stack_buf[64];
+    uint8_t* digits = stack_buf;
+    bool heap = false;
+    if (len > sizeof(stack_buf)) {
+        digits = (uint8_t*)malloc(len);
+        if (!digits) {
+            return NULL;
+        }
+        heap = true;
+    }
+    size_t count = 0;
+    for (size_t i = 0; i < len; i++) {
+        if (isdigit((unsigned char)path[i])) {
+            digits[count++] = (uint8_t)(path[i] - '0');
         }
     }
+    decimal_cell_t* node = decimal_cell_find_path(root, digits, count);
+    if (heap) {
+        free(digits);
+    }
+    return node;
+}
+
+void decimal_cell_mark_sync(decimal_cell_t* root,
+                            const uint8_t* path,
+                            size_t path_len,
+                            uint64_t timestamp) {
+    if (!root) return;
+    if (path_len == 0) {
+        root->last_sync_time = timestamp;
+        root->is_active = true;
+        root->last_state_change = timestamp;
+        return;
+    }
+    decimal_cell_t* current = root;
+    for (size_t i = 0; i < path_len; i++) {
+        uint8_t digit = path[i] % DECIMAL_CELL_FANOUT;
+        if (!current->children[digit]) {
+            return;
+        }
+        current->child_last_sync[digit] = timestamp;
+        current->child_last_state_change[digit] = timestamp;
+        current->child_active[digit] = true;
+        current->last_sync_time = timestamp;
+        current = current->children[digit];
+        current->is_active = true;
+        current->last_sync_time = timestamp;
+        current->last_state_change = timestamp;
+    }
+}
+
+void decimal_cell_deactivate_path(decimal_cell_t* root,
+                                  const uint8_t* path,
+                                  size_t path_len,
+                                  uint64_t timestamp) {
+    if (!root) return;
+    if (path_len == 0) {
+        deactivate_recursive(root, NULL, 0, timestamp);
+        return;
+    }
+    deactivate_recursive(root, path, path_len, timestamp);
+}
+
+void decimal_cell_update_state(decimal_cell_t* cell, uint64_t now) {
+    if (!cell) return;
+    if (cell->is_active && (now - cell->last_sync_time) > cell->sync_interval * 3) {
+        cell->is_active = false;
+        cell->last_state_change = now;
+    }
+    for (uint8_t d = 0; d < DECIMAL_CELL_FANOUT; d++) {
+        if (!cell->children[d]) continue;
+        if (cell->child_active[d] && (now - cell->child_last_sync[d]) > cell->sync_interval * 3) {
+            cell->child_active[d] = false;
+            cell->child_last_state_change[d] = now;
+        }
+        decimal_cell_update_state(cell->children[d], now);
+    }
+}
+
+size_t decimal_cell_collect_active_children(const decimal_cell_t* cell,
+                                            uint8_t* out_digits,
+                                            size_t max_digits) {
+    if (!cell || !out_digits || max_digits == 0) return 0;
+    size_t count = 0;
+    for (uint8_t d = 0; d < DECIMAL_CELL_FANOUT && count < max_digits; d++) {
+        if (cell->children[d] && cell->child_active[d]) {
+            out_digits[count++] = d;
+        }
+    }
+    return count;
+}
+
+size_t decimal_cell_serialize(const decimal_cell_t* cell, char* buffer, size_t buffer_size) {
+    if (!cell) {
+        if (buffer_size > 0) buffer[0] = '\0';
+        return 0;
+    }
+    size_t total = serialize_node_internal(cell, buffer, buffer_size, 0);
+    if (buffer_size > 0) {
+        size_t term = (total < buffer_size - 1) ? total : (buffer_size - 1);
+        buffer[term] = '\0';
+    }
+    return total;
 }

--- a/src/kolibri_node_v1.c
+++ b/src/kolibri_node_v1.c
@@ -102,7 +102,7 @@ void send_hello_to_neighbor(struct sockaddr_in* addr) {
     memset(msg, 0, sizeof(msg));
     memcpy(msg, MAGIC_BYTES, MAGIC_LEN);
     msg[MAGIC_LEN] = MSG_HELLO;
-    msg[MAGIC_LEN+1] = cell.node_digit;
+    msg[MAGIC_LEN+1] = cell.digit;
     sendto(server_sock, msg, MAGIC_LEN+2, 0, (struct sockaddr*)addr, sizeof(*addr));
 }
 
@@ -133,7 +133,7 @@ uint64_t now_ms(void) {
     return (uint64_t)ts.tv_sec * 1000 + (uint64_t)ts.tv_nsec / 1000000;
 }
 
-/* Локальная функция add_neighbor удалена, используем add_neighbor(&cell, digit) из kolibri_decimal_cell.h */
+/* Локальная функция add_neighbor удалена, используем decimal_cell_add_path(&cell, path, len, true) */
 
 // ==========================
 // Network handling
@@ -210,7 +210,7 @@ static void process_message(const char* data, size_t len, struct sockaddr_in* sr
             // Ответить ACK
             response[MAGIC_LEN] = MSG_ACK;
             memcpy(response, MAGIC_BYTES, MAGIC_LEN);
-            response[MAGIC_LEN+1] = cell.node_digit;
+            response[MAGIC_LEN+1] = cell.digit;
             response_len = MAGIC_LEN + 2;
             sendto(server_sock, response, response_len, 0, (struct sockaddr*)src_addr, sizeof(*src_addr));
             // Пример: считаем успешное применение первого правила (для демонстрации)
@@ -227,6 +227,9 @@ static void process_message(const char* data, size_t len, struct sockaddr_in* sr
         case MSG_ACK: {
             uint8_t from_digit = (len > MAGIC_LEN+1) ? (uint8_t)data[MAGIC_LEN+1] : 255;
             printf("[DEBUG] Received ACK from node %d\n", from_digit);
+            if (from_digit < DECIMAL_CELL_FANOUT) {
+                decimal_cell_mark_sync(&cell, &from_digit, 1, now_ms());
+            }
             break;
         }
         case 42: { // MSG_MIGRATE_RULE
@@ -280,37 +283,43 @@ void create_metarule(void) {
 // Замена неактивных соседей на новые
 void adapt_neighbors(void) {
     uint64_t now = now_ms();
-    for (int i = 0; i < cell.n_neighbors; i++) {
-        if (!cell.is_active[i] && (now - cell.last_sync[i] > 90000)) {
-            // Найти новую цифру, не совпадающую с текущими
-            uint8_t used[10] = {0};
-            used[cell.node_digit] = 1;
-            for (int j = 0; j < cell.n_neighbors; j++) used[cell.neighbor_digits[j]] = 1;
-            for (uint8_t d = 0; d < 10; d++) {
-                if (!used[d]) {
-                    cell.neighbor_digits[i] = d;
-                    cell.last_sync[i] = now;
-                    cell.is_active[i] = true;
-                    printf("[TOPOLOGY] Neighbor %d replaced by digit %d\n", i, d);
-                    break;
-                }
+    for (uint8_t digit = 0; digit < DECIMAL_CELL_FANOUT; digit++) {
+        if (!cell.children[digit]) continue;
+        if (cell.child_active[digit]) continue;
+        if ((now - cell.child_last_sync[digit]) <= 90000) continue;
+
+        bool used[DECIMAL_CELL_FANOUT] = {0};
+        used[cell.digit] = true;
+        for (uint8_t existing = 0; existing < DECIMAL_CELL_FANOUT; existing++) {
+            if (cell.children[existing] && cell.child_active[existing]) {
+                used[existing] = true;
             }
+        }
+
+        for (uint8_t candidate = 0; candidate < DECIMAL_CELL_FANOUT; candidate++) {
+            if (used[candidate]) continue;
+            decimal_cell_deactivate_path(&cell, &digit, 1, now);
+            decimal_cell_add_path(&cell, &candidate, 1, true);
+            printf("[TOPOLOGY] Neighbor %u replaced by digit %u\n", digit, candidate);
+            break;
         }
     }
 }
 
 // Отправка лучшего правила соседу
 void migrate_best_rule(void) {
-    if (rules.count == 0 || cell.n_neighbors == 0) return;
+    uint8_t neighbors[DECIMAL_CELL_FANOUT];
+    size_t neighbor_count = decimal_cell_collect_active_children(&cell, neighbors, DECIMAL_CELL_FANOUT);
+    if (rules.count == 0 || neighbor_count == 0) return;
     // Находим правило с максимальным fitness
     int best = 0;
     for (int i = 1; i < rules.count; i++) {
         if (rules.fitness[i] > rules.fitness[best]) best = i;
     }
     // Выбираем случайного соседа
-    int nidx = rand() % cell.n_neighbors;
+    int nidx = rand() % (int)neighbor_count;
     struct sockaddr_in n_addr;
-    fill_neighbor_addr(cell.neighbor_digits[nidx], &n_addr, DEFAULT_PORT);
+    fill_neighbor_addr(neighbors[nidx], &n_addr, DEFAULT_PORT);
     // Формируем сообщение (MAGIC + тип + pattern + action + tier + fitness)
     char msg[BUFFER_SIZE];
     memset(msg, 0, sizeof(msg));
@@ -319,7 +328,7 @@ void migrate_best_rule(void) {
     int off = MAGIC_LEN + 1;
     int plen = snprintf(msg+off, sizeof(msg)-off, "%s|%s|%d|%.4f", rules.patterns[best], rules.actions[best], rules.tiers[best], rules.fitness[best]);
     sendto(server_sock, msg, off+plen, 0, (struct sockaddr*)&n_addr, sizeof(n_addr));
-    printf("[MIGRATE] Sent best rule to neighbor %d: %s -> %s\n", cell.neighbor_digits[nidx], rules.patterns[best], rules.actions[best]);
+    printf("[MIGRATE] Sent best rule to neighbor %d: %s -> %s\n", neighbors[nidx], rules.patterns[best], rules.actions[best]);
 }
 
 // ==========================
@@ -345,9 +354,11 @@ static void run_server(void) {
         uint64_t t = now_ms();
         // Периодическая синхронизация с соседями (HELLO)
         if (t - last_sync > 1000) {
-            for (int i = 0; i < cell.n_neighbors; i++) {
+            uint8_t neighbors[DECIMAL_CELL_FANOUT];
+            size_t neighbor_count = decimal_cell_collect_active_children(&cell, neighbors, DECIMAL_CELL_FANOUT);
+            for (size_t i = 0; i < neighbor_count; i++) {
                 struct sockaddr_in n_addr;
-                fill_neighbor_addr(cell.neighbor_digits[i], &n_addr, DEFAULT_PORT);
+                fill_neighbor_addr(neighbors[i], &n_addr, DEFAULT_PORT);
                 send_hello_to_neighbor(&n_addr);
             }
             last_sync = t;
@@ -374,10 +385,13 @@ static void run_server(void) {
                        (uint64_t)t, i, rules.patterns[i], rules.actions[i],
                        rules.tiers[i], rules.fitness[i]);
             }
-            for (int i = 0; i < cell.n_neighbors; i++) {
-                printf("T=%" PRIu64 " NEIGHBOR=%d digit=%d active=%d last_sync=%" PRIu64 "\n",
-                       (uint64_t)t, i, cell.neighbor_digits[i],
-                       cell.neighbor_digits[i] != 255, (uint64_t)cell.last_sync[i]);
+            for (uint8_t digit = 0; digit < DECIMAL_CELL_FANOUT; digit++) {
+                if (!cell.children[digit]) continue;
+                printf("T=%" PRIu64 " NEIGHBOR_DIGIT=%u active=%d last_sync=%" PRIu64 "\n",
+                       (uint64_t)t,
+                       digit,
+                       cell.child_active[digit] ? 1 : 0,
+                       (uint64_t)cell.child_last_sync[digit]);
             }
             last_log = t;
         }
@@ -462,7 +476,7 @@ int main(int argc, char** argv) {
     // Добавляем 9 соседей (все цифры кроме своей)
     for (uint8_t d = 0; d < 10; d++) {
         if (d == my_digit) continue;
-        add_neighbor(&cell, d);
+        decimal_cell_add_path(&cell, &d, 1, true);
     }
 
     // Инициализация AI подсистемы

--- a/tests/test_decimal_cell.c
+++ b/tests/test_decimal_cell.c
@@ -1,0 +1,93 @@
+#include <stdio.h>
+#include <string.h>
+#include <sys/time.h>
+
+#include "../src/kolibri_decimal_cell.h"
+
+uint64_t now_ms(void) {
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    return (uint64_t)tv.tv_sec * 1000 + (uint64_t)tv.tv_usec / 1000;
+}
+
+static void print_result(const char* name, int ok) {
+    if (ok) {
+        printf("OK: %s\n", name);
+    } else {
+        printf("FAIL: %s\n", name);
+    }
+}
+
+int main(void) {
+    int failures = 0;
+    decimal_cell_t root;
+    init_decimal_cell(&root, 5);
+
+    uint8_t path123[] = {1, 2, 3};
+    decimal_cell_t* node123 = decimal_cell_add_path(&root, path123, 3, true);
+    int ok = (node123 != NULL && node123->depth == 3 && node123->digit == 3);
+    print_result("add_path depth-3", ok);
+    failures += ok ? 0 : 1;
+
+    decimal_cell_t* found = decimal_cell_find_path(&root, path123, 3);
+    ok = (found == node123);
+    print_result("find_path existing", ok);
+    failures += ok ? 0 : 1;
+
+    decimal_cell_t* node478 = decimal_cell_add_path_str(&root, "478", true);
+    ok = (node478 != NULL && node478->depth == 3 && node478->digit == 8);
+    print_result("add_path_str", ok);
+    failures += ok ? 0 : 1;
+
+    decimal_cell_t* found_str = decimal_cell_find_path_str(&root, "478");
+    ok = (found_str == node478);
+    print_result("find_path_str", ok);
+    failures += ok ? 0 : 1;
+
+    uint8_t neighbors[DECIMAL_CELL_FANOUT];
+    size_t neighbor_count = decimal_cell_collect_active_children(&root, neighbors, DECIMAL_CELL_FANOUT);
+    ok = (neighbor_count == 2);
+    print_result("collect_active_children", ok);
+    failures += ok ? 0 : 1;
+
+    uint8_t path478[] = {4, 7, 8};
+    uint64_t deactivate_ts = now_ms();
+    decimal_cell_deactivate_path(&root, path478, 3, deactivate_ts);
+    found_str = decimal_cell_find_path_str(&root, "478");
+    ok = (found_str == NULL);
+    print_result("deactivate_path", ok);
+    failures += ok ? 0 : 1;
+
+    neighbor_count = decimal_cell_collect_active_children(&root, neighbors, DECIMAL_CELL_FANOUT);
+    ok = (neighbor_count == 1 && neighbors[0] == 1);
+    print_result("collect_after_deactivate", ok);
+    failures += ok ? 0 : 1;
+
+    uint64_t mark_time = now_ms();
+    decimal_cell_mark_sync(&root, path123, 3, mark_time);
+    ok = (root.child_last_sync[1] == mark_time && node123->last_sync_time == mark_time);
+    print_result("mark_sync", ok);
+    failures += ok ? 0 : 1;
+
+    decimal_cell_update_state(&root, mark_time + root.sync_interval * 4);
+    ok = (!root.child_active[1] && !node123->is_active);
+    print_result("update_state_timeout", ok);
+    failures += ok ? 0 : 1;
+
+    char buffer[1024];
+    decimal_cell_serialize(&root, buffer, sizeof(buffer));
+    ok = (strstr(buffer, "\"digit\":5") != NULL && strstr(buffer, "\"children\"") != NULL);
+    print_result("serialize_contains", ok);
+    failures += ok ? 0 : 1;
+
+    cleanup_decimal_cell(&root);
+    int remaining = 0;
+    for (uint8_t d = 0; d < DECIMAL_CELL_FANOUT; d++) {
+        if (root.children[d]) remaining++;
+    }
+    ok = (remaining == 0);
+    print_result("cleanup_no_children", ok);
+    failures += ok ? 0 : 1;
+
+    return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
- redesign the decimal cell data structure into a hierarchical tree with path-based APIs and serialization helpers
- update node logic and HTTP status reporting to traverse children by digit paths and keep timing in sync
- register a new unit test target and add coverage for multi-level activation, deactivation, serialization, and cleanup

## Testing
- `./test_decimal_cell`
- `cmake -S . -B build` *(fails: missing json-c pkg-config dependency in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d2a78ac1e483239e18e405eb0a6168