### PR TITLE
Fix difficulty adjustment traversal and add blockchain tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,13 @@ target_include_directories(test_formula PRIVATE
         ${CMAKE_SOURCE_DIR}/include
         ${JSONC_INCLUDE_DIRS})
 
+add_executable(test_blockchain tests/test_blockchain.c src/kovian_blockchain.c src/formula.c)
+target_link_libraries(test_blockchain PRIVATE ${JSONC_LIBRARIES} OpenSSL::Crypto m)
+target_include_directories(test_blockchain PRIVATE
+        ${CMAKE_SOURCE_DIR}/src
+        ${CMAKE_SOURCE_DIR}/include
+        ${JSONC_INCLUDE_DIRS})
+
 # Добавляем пути к заголовочным файлам для веб-интерфейса
 target_include_directories(web_interface PRIVATE
     ${CMAKE_SOURCE_DIR}/src

--- a/tests/test_blockchain.c
+++ b/tests/test_blockchain.c
@@ -1,0 +1,67 @@
+#include <assert.h>
+#include <math.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+
+#include "kovian_blockchain.h"
+
+static void init_formula(Formula* formula, double effectiveness, int index) {
+    memset(formula, 0, sizeof(*formula));
+    snprintf(formula->id, sizeof(formula->id), "formula_%03d", index);
+    formula->effectiveness = effectiveness;
+    formula->created_at = time(NULL);
+    formula->representation = FORMULA_REPRESENTATION_TEXT;
+    snprintf(formula->content, sizeof(formula->content), "content_%03d", index);
+}
+
+static void build_chain(KovianChain* chain, size_t total_blocks, double low_effectiveness,
+                        double high_effectiveness, size_t high_tail) {
+    assert(chain);
+    assert(total_blocks >= high_tail);
+
+    Formula formula;
+    for (size_t i = 0; i < total_blocks; ++i) {
+        double effectiveness = (i < total_blocks - high_tail) ? low_effectiveness : high_effectiveness;
+        init_formula(&formula, effectiveness, (int)i);
+        assert(kovian_chain_add_block(chain, &formula, 1) != NULL);
+    }
+    assert(chain->length == total_blocks);
+}
+
+static void test_adjust_difficulty_increase(void) {
+    KovianChain* chain = kovian_chain_create();
+    assert(chain);
+
+    build_chain(chain, 110, 0.5, 0.9, 100);
+
+    double initial_difficulty = chain->difficulty;
+    adjust_chain_difficulty(chain);
+
+    double expected = initial_difficulty * 1.1;
+    assert(fabs(chain->difficulty - expected) < 1e-9);
+
+    kovian_chain_destroy(chain);
+}
+
+static void test_adjust_difficulty_decrease(void) {
+    KovianChain* chain = kovian_chain_create();
+    assert(chain);
+
+    build_chain(chain, 120, 0.95, 0.3, 100);
+
+    double initial_difficulty = chain->difficulty;
+    adjust_chain_difficulty(chain);
+
+    double expected = initial_difficulty * 0.9;
+    assert(fabs(chain->difficulty - expected) < 1e-9);
+
+    kovian_chain_destroy(chain);
+}
+
+int main(void) {
+    test_adjust_difficulty_increase();
+    test_adjust_difficulty_decrease();
+    printf("All blockchain difficulty adjustment tests passed.\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- walk the blockchain from genesis when computing the moving window for difficulty adjustment to avoid using invalid next pointers
- add a dedicated blockchain difficulty test that builds long chains and validates both increase and decrease scenarios
- wire the new blockchain test target into the CMake configuration

## Testing
- cmake -S . -B build
- cmake --build build --target test_blockchain
- ./build/test_blockchain

------
https://chatgpt.com/codex/tasks/task_e_68d2aa4df2bc83238866f1011694417a