### PR TITLE
Deep copy blockchain block formulas

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,13 @@ target_include_directories(test_blockchain PRIVATE
         ${CMAKE_SOURCE_DIR}/include
         ${JSONC_INCLUDE_DIRS})
 
+add_executable(test_blockchain_storage tests/test_blockchain_storage.c src/blockchain.c src/formula.c src/formula_advanced.c)
+target_link_libraries(test_blockchain_storage PRIVATE ${JSONC_LIBRARIES} OpenSSL::Crypto m)
+target_include_directories(test_blockchain_storage PRIVATE
+        ${CMAKE_SOURCE_DIR}/src
+        ${CMAKE_SOURCE_DIR}/include
+        ${JSONC_INCLUDE_DIRS})
+
 # Добавляем пути к заголовочным файлам для веб-интерфейса
 target_include_directories(web_interface PRIVATE
     ${CMAKE_SOURCE_DIR}/src

--- a/tests/test_blockchain_storage.c
+++ b/tests/test_blockchain_storage.c
@@ -1,0 +1,59 @@
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+
+#include "blockchain.h"
+#include "formula.h"
+
+static void init_text_formula(Formula* formula, const char* id, const char* content) {
+    memset(formula, 0, sizeof(*formula));
+    strncpy(formula->id, id, sizeof(formula->id) - 1);
+    formula->effectiveness = 0.42;
+    formula->created_at = time(NULL);
+    formula->representation = FORMULA_REPRESENTATION_TEXT;
+    strncpy(formula->content, content, sizeof(formula->content) - 1);
+}
+
+static void test_blockchain_stores_deep_copies(void) {
+    Blockchain* chain = blockchain_create();
+    assert(chain);
+
+    Formula original;
+    init_text_formula(&original, "formula_001", "original payload");
+
+    Formula* formulas[] = { &original };
+    assert(blockchain_add_block(chain, formulas, 1));
+    assert(chain->block_count == 1);
+
+    Block* stored_block = chain->blocks[0];
+    assert(stored_block);
+    assert(stored_block->formula_count == 1);
+
+    Formula* stored_formula = stored_block->formulas[0];
+    assert(stored_formula);
+    assert(stored_formula != &original);
+    assert(strcmp(stored_formula->content, "original payload") == 0);
+
+    char initial_hash[65];
+    const char* hash_before = blockchain_get_last_hash(chain);
+    strncpy(initial_hash, hash_before, sizeof(initial_hash));
+    initial_hash[sizeof(initial_hash) - 1] = '\0';
+
+    // Mutate the original formula after it has been added to the chain.
+    strncpy(original.content, "mutated payload", sizeof(original.content) - 1);
+    original.effectiveness = 0.99;
+
+    const char* hash_after = blockchain_get_last_hash(chain);
+    assert(strcmp(initial_hash, hash_after) == 0);
+    assert(strcmp(stored_formula->content, "original payload") == 0);
+    assert(stored_formula->effectiveness == 0.42);
+
+    blockchain_destroy(chain);
+}
+
+int main(void) {
+    test_blockchain_stores_deep_copies();
+    printf("Blockchain storage deep copy test passed.\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- deep-copy blockchain block formulas into block-owned storage to prevent external mutation from affecting persisted data
- release cloned formulas during blockchain destruction to avoid leaks
- add a unit test verifying stored block contents and hash remain stable when source formulas are mutated

## Testing
- `cmake --build build --target test_blockchain_storage`
- `./build/test_blockchain_storage`


------
https://chatgpt.com/codex/tasks/task_e_68d2b0e6d9488323906c3c0c6c2972c4