### PR TITLE
Handle HTTP request bodies with dynamic buffers

### DIFF
--- a/cfg/kolibri.jsonc
+++ b/cfg/kolibri.jsonc
@@ -2,7 +2,8 @@
   // HTTP configuration
   "http": {
     "host": "0.0.0.0",
-    "port": 9000
+    "port": 9000,
+    "max_body_size": 1048576
   },
   // VM execution defaults
   "vm": {

--- a/include/util/config.h
+++ b/include/util/config.h
@@ -11,6 +11,7 @@ extern "C" {
 typedef struct {
     char host[64];
     uint16_t port;
+    uint32_t max_body_size;
 } http_config_t;
 
 typedef struct {

--- a/src/http/http_server.c
+++ b/src/http/http_server.c
@@ -82,19 +82,108 @@ static const char *find_header(const char *haystack, const char *needle) {
     return NULL;
 }
 
-static ssize_t read_request(int client, char *buffer, size_t buf_len) {
-    ssize_t total = 0;
-    while (total < (ssize_t)buf_len) {
-        ssize_t n = recv(client, buffer + total, buf_len - total, 0);
-        if (n <= 0) {
-            return n;
+static int read_request(int client,
+                        char **out_buffer,
+                        size_t *out_len,
+                        size_t *out_header_len,
+                        size_t max_body) {
+    if (!out_buffer || !out_len || !out_header_len) {
+        return -1;
+    }
+
+    size_t capacity = RECV_BUFFER;
+    char *buffer = calloc(1, capacity + 1);
+    if (!buffer) {
+        return -1;
+    }
+
+    size_t total = 0;
+    size_t header_len = 0;
+    size_t content_length = 0;
+    int have_content_length = 0;
+
+    while (1) {
+        if (total >= capacity) {
+            size_t new_capacity = capacity * 2;
+            char *tmp = realloc(buffer, new_capacity + 1);
+            if (!tmp) {
+                free(buffer);
+                return -1;
+            }
+            buffer = tmp;
+            capacity = new_capacity;
         }
-        total += n;
-        if (strstr(buffer, "\r\n\r\n")) {
-            break;
+
+        ssize_t n = recv(client, buffer + total, capacity - total, 0);
+        if (n <= 0) {
+            free(buffer);
+            return -1;
+        }
+        total += (size_t)n;
+        buffer[total] = '\0';
+
+        if (header_len == 0) {
+            char *headers_end = strstr(buffer, "\r\n\r\n");
+            if (headers_end) {
+                header_len = (size_t)(headers_end - buffer) + 4;
+                size_t header_text_len = header_len >= 4 ? header_len - 4 : header_len;
+                char saved = buffer[header_text_len];
+                buffer[header_text_len] = '\0';
+                const char *cl_hdr = find_header(buffer, "content-length:");
+                buffer[header_text_len] = saved;
+                if (cl_hdr) {
+                    content_length = (size_t)strtoul(cl_hdr + 15, NULL, 10);
+                    have_content_length = 1;
+                }
+
+                if (have_content_length && max_body > 0 && content_length > max_body) {
+                    free(buffer);
+                    return -2;
+                }
+
+                if (have_content_length && content_length > SIZE_MAX - header_len) {
+                    free(buffer);
+                    return -1;
+                }
+
+                size_t required = header_len + content_length;
+                if (required > capacity) {
+                    size_t new_capacity = required;
+                    char *tmp = realloc(buffer, new_capacity + 1);
+                    if (!tmp) {
+                        free(buffer);
+                        return -1;
+                    }
+                    buffer = tmp;
+                    capacity = new_capacity;
+                }
+
+                if (total >= required) {
+                    break;
+                }
+            }
+        } else {
+            size_t required = header_len + content_length;
+            if (total >= required) {
+                break;
+            }
+            if (required > capacity) {
+                size_t new_capacity = required;
+                char *tmp = realloc(buffer, new_capacity + 1);
+                if (!tmp) {
+                    free(buffer);
+                    return -1;
+                }
+                buffer = tmp;
+                capacity = new_capacity;
+            }
         }
     }
-    return total;
+
+    *out_buffer = buffer;
+    *out_len = total;
+    *out_header_len = header_len;
+    return 0;
 }
 
 static const char *status_reason(int status) {
@@ -105,6 +194,8 @@ static const char *status_reason(int status) {
         return "Bad Request";
     case 404:
         return "Not Found";
+    case 413:
+        return "Payload Too Large";
     case 500:
     default:
         return "Internal Server Error";
@@ -127,41 +218,52 @@ static void send_response(int client, const http_response_t *resp) {
     }
 }
 
+static void send_payload_too_large(int client) {
+    http_response_t resp = {0};
+    resp.status = 413;
+    snprintf(resp.content_type, sizeof(resp.content_type), "application/json");
+    resp.data = strdup("{\"error\":\"payload too large\"}");
+    resp.len = strlen(resp.data);
+    send_response(client, &resp);
+    http_response_free(&resp);
+}
+
 static void handle_client(int client) {
-    char buffer[RECV_BUFFER + 1];
-    memset(buffer, 0, sizeof(buffer));
-    ssize_t received = read_request(client, buffer, RECV_BUFFER);
-    if (received <= 0) {
+    char *buffer = NULL;
+    size_t received = 0;
+    size_t header_len = 0;
+    int rc = read_request(client,
+                          &buffer,
+                          &received,
+                          &header_len,
+                          server.cfg.http.max_body_size);
+    if (rc == -2) {
+        send_payload_too_large(client);
+        return;
+    }
+    if (rc != 0) {
         return;
     }
 
     char method[8];
     char path[256];
     if (sscanf(buffer, "%7s %255s", method, path) != 2) {
+        free(buffer);
         return;
     }
 
-    const char *headers_end = strstr(buffer, "\r\n\r\n");
-    size_t header_len = headers_end ? (size_t)(headers_end - buffer + 4) : (size_t)received;
-    size_t body_len = (size_t)received - header_len;
-    char *body = buffer + header_len;
-
-    const char *cl_hdr = find_header(buffer, "content-length:");
-    size_t content_length = body_len;
-    if (cl_hdr) {
-        content_length = (size_t)strtoul(cl_hdr + 15, NULL, 10);
+    if (header_len == 0 || header_len > received) {
+        free(buffer);
+        return;
     }
 
-    if (content_length > body_len) {
-        size_t to_read = content_length - body_len;
-        if (to_read + received > RECV_BUFFER) {
-            to_read = RECV_BUFFER - received;
-        }
-        ssize_t n = recv(client, buffer + received, to_read, 0);
-        if (n > 0) {
-            received += n;
-            body_len += (size_t)n;
-        }
+    size_t body_len = received - header_len;
+    char *body = buffer + header_len;
+
+    if (server.cfg.http.max_body_size > 0 && body_len > server.cfg.http.max_body_size) {
+        send_payload_too_large(client);
+        free(buffer);
+        return;
     }
 
     http_response_t resp = {0};
@@ -173,6 +275,7 @@ static void handle_client(int client) {
     }
     send_response(client, &resp);
     http_response_free(&resp);
+    free(buffer);
 }
 
 static void *server_loop(void *arg) {

--- a/src/util/config.c
+++ b/src/util/config.c
@@ -9,6 +9,7 @@ static void set_defaults(kolibri_config_t *cfg) {
     memset(cfg, 0, sizeof(*cfg));
     strncpy(cfg->http.host, "0.0.0.0", sizeof(cfg->http.host) - 1);
     cfg->http.port = 9000;
+    cfg->http.max_body_size = 1024 * 1024;
     cfg->vm.max_steps = 2048;
     cfg->vm.max_stack = 128;
     cfg->vm.trace_depth = 64;
@@ -109,6 +110,7 @@ int config_load(const char *path, kolibri_config_t *cfg) {
 
     parse_string(buf, "host", cfg->http.host, sizeof(cfg->http.host));
     parse_uint(buf, "port", (uint32_t *)&cfg->http.port);
+    parse_uint(buf, "max_body_size", &cfg->http.max_body_size);
     parse_uint(buf, "max_steps", &cfg->vm.max_steps);
     parse_uint(buf, "max_stack", &cfg->vm.max_stack);
     parse_uint(buf, "trace_depth", &cfg->vm.trace_depth);


### PR DESCRIPTION
## Summary
- allocate dynamic request buffers based on Content-Length and fully read HTTP bodies
- pass dynamically owned bodies to the route handler and free them after handling
- add configurable max_body_size enforcement that responds with 413 when the request exceeds the limit

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68d30cc8ad508323883e257504f1b041