### PR TITLE
Add HALT opcode handling in VM

### DIFF
--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -46,6 +46,7 @@ typedef struct {
     vm_status_t status;
     uint64_t result;
     uint32_t steps;
+    uint8_t halted;
 } vm_result_t;
 
 int vm_run(const prog_t *p, const vm_limits_t *lim, vm_trace_t *trace, vm_result_t *out);

--- a/src/http/http_routes.c
+++ b/src/http/http_routes.c
@@ -357,10 +357,11 @@ static void respond_run(const kolibri_config_t *cfg, const uint8_t *prog_bytes, 
         return;
     }
     int written = snprintf(json, cap,
-                           "{\"status\":%d,\"steps\":%u,\"result\":%llu,\"trace\":[",
+                           "{\"status\":%d,\"steps\":%u,\"result\":%llu,\"halted\":%u,\"trace\":[",
                            result.status,
                            result.steps,
-                           (unsigned long long)result.result);
+                           (unsigned long long)result.result,
+                           (unsigned)result.halted);
     if (written < 0) {
         free(json);
         free(entries);

--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -82,6 +82,7 @@ int vm_run(const prog_t *p, const vm_limits_t *lim, vm_trace_t *trace, vm_result
     uint16_t call_stack[CALL_STACK_MAX];
     size_t call_sp = 0;
     vm_status_t status = VM_OK;
+    uint8_t halted = 0;
 
     if (trace) {
         trace->count = 0;
@@ -337,6 +338,11 @@ int vm_run(const prog_t *p, const vm_limits_t *lim, vm_trace_t *trace, vm_result
         }
         case 0x11: // NOP
             break;
+        case 0x12: { // HALT
+            status = VM_OK;
+            halted = 1;
+            goto done;
+        }
         default:
             status = VM_ERR_INVALID_OPCODE;
             goto done;
@@ -348,6 +354,7 @@ done:
         out->status = status;
         out->steps = steps;
         out->result = (sp > 0) ? (uint64_t)stack[sp - 1] : 0;
+        out->halted = halted;
     }
     free(stack);
     return 0;

--- a/tests/unit/test_vm.c
+++ b/tests/unit/test_vm.c
@@ -108,10 +108,27 @@ static void test_div_zero(void) {
     free(bb.data);
 }
 
+static void test_halt(void) {
+    uint8_t code[] = {0x01, 0x05, 0x12, 0x01, 0x09};
+    prog_t prog = {code, sizeof(code)};
+    vm_limits_t lim = {512, 128};
+    vm_trace_entry_t entries[8];
+    vm_trace_t trace = {entries, 8, 0, 0};
+    vm_result_t out;
+    assert(vm_run(&prog, &lim, &trace, &out) == 0);
+    assert(out.status == VM_OK);
+    assert(out.halted == 1);
+    assert(out.steps == 2);
+    assert(out.result == 5);
+    assert(trace.count == 2);
+    assert(trace.entries[1].opcode == 0x12);
+}
+
 int main(void) {
     test_add();
     test_mul();
     test_div_zero();
+    test_halt();
     printf("vm tests passed\n");
     return 0;
 }


### PR DESCRIPTION
## Summary
- handle the HALT (0x12) opcode in the VM loop and flag halting in the result
- extend vm_result_t and HTTP response payloads to expose the halt state
- add a unit test ensuring programs stop on HALT and trace the final step

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68d30ce563d08323a2358b38c0e1d4b3