### PR TITLE
feat(web): add localized dialog API errors

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -106,6 +106,36 @@ export class ApiError<T = unknown> extends Error {
   }
 }
 
+const STATUS_MESSAGES: Record<number, string> = {
+  400: "Некорректный запрос к API диалога. Проверьте отправляемые данные.",
+  401: "Требуется аутентификация для обращения к ядру Kolibri Ω.",
+  403: "Доступ к диалоговому эндпоинту запрещён.",
+  404: "Эндпоинт диалога недоступен, проверьте запуск ядра Kolibri Ω.",
+  409: "Конфликт при обращении к диалоговому API. Повторите попытку позже.",
+  429: "Превышен лимит обращений к ядру Kolibri Ω. Подождите перед новой попыткой.",
+  500: "Внутренняя ошибка ядра Kolibri Ω. Проверьте логи сервиса.",
+  502: "Некорректный ответ от backend. Убедитесь, что сервис запущен корректно.",
+  503: "Диалоговый сервис временно недоступен. Попробуйте повторить запрос позже.",
+  504: "Превышено время ожидания ответа от ядра Kolibri Ω."
+};
+
+export function formatApiError(error: unknown): string {
+  if (error instanceof ApiError) {
+    const predefined = STATUS_MESSAGES[error.status];
+    if (predefined) {
+      return predefined;
+    }
+    const fallback = error.message || "Запрос к API завершился ошибкой.";
+    return `Ошибка API (${error.status}). ${fallback}`;
+  }
+
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return "Неизвестная ошибка";
+}
+
 interface RequestOptions extends RequestInit {
   skipJson?: boolean;
 }

--- a/web/src/views/DialogView.tsx
+++ b/web/src/views/DialogView.tsx
@@ -1,5 +1,5 @@
 import { FormEvent, useMemo, useState } from "react";
-import { apiClient } from "../api/client";
+import { apiClient, formatApiError } from "../api/client";
 import { Spinner } from "../components/Spinner";
 import { useNotifications } from "../components/NotificationCenter";
 
@@ -79,7 +79,7 @@ export function DialogView() {
       setHistory((prev) => [entry, ...prev].slice(0, 20));
       notify({ title: "Диалог выполнен", message: "Ответ получен от ядра Kolibri Ω", type: "success", timeout: 3500 });
     } catch (error) {
-      const message = error instanceof Error ? error.message : "Неизвестная ошибка";
+      const message = formatApiError(error);
       notify({ title: "Ошибка диалога", message, type: "error" });
     } finally {
       setIsLoading(false);


### PR DESCRIPTION
## Summary
- add a reusable API error formatter that maps common HTTP statuses to Russian hints
- reuse the formatter in the dialog view to surface localized messages to operators

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3398efa548323824e9d7199920afd