### PR TITLE
Fix Makefile SRC list formatting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,6 @@ SRC := \
   src/util/config.c \
   src/vm/vm.c \
   src/fkv/fkv.c \
-
   src/kolibri_ai.c \
   src/http/http_server.c \
   src/http/http_routes.c \


### PR DESCRIPTION
## Summary
- remove the blank line inside the SRC assignment so the multiline continuation remains valid

## Testing
- make build (fails: include/util/config.h:28:1: error: expected specifier-qualifier-list before ‘typedef’)


------
https://chatgpt.com/codex/tasks/task_e_68d3424a20f083238579a7e28753fbf6