### PR TITLE
Fix kolibri_ai.h dependencies

### DIFF
--- a/include/kolibri_ai.h
+++ b/include/kolibri_ai.h
@@ -4,7 +4,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
-
+#include "formula_core.h"
+#include "synthesis/selfplay.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -35,7 +36,7 @@ typedef enum {
     KOLIBRI_DIFFICULTY_CHALLENGE = 3
 } KolibriDifficultyLevel;
 
-KolibriAI *kolibri_ai_create(const kolibri_config_t *cfg);
+KolibriAI *kolibri_ai_create(const struct kolibri_config_t *cfg);
 void kolibri_ai_destroy(KolibriAI *ai);
 
 void kolibri_ai_start(KolibriAI *ai);


### PR DESCRIPTION
## Summary
- include the selfplay and formula core headers in kolibri_ai.h so the associated types are defined
- use an explicit struct reference for kolibri_config_t to keep the header self-contained

## Testing
- `gcc -std=c11 -Iinclude -c src/kolibri_ai.c -o /tmp/kolibri_ai.o`
- `echo '#include "kolibri_ai.h"' | gcc -std=c11 -Iinclude -c -x c -o /tmp/test_header.o -`


------
https://chatgpt.com/codex/tasks/task_e_68d3424da3c88323910a5a9380af950e