### PR TITLE
Define configuration structs used by config loader

### DIFF
--- a/include/kolibri_ai.h
+++ b/include/kolibri_ai.h
@@ -13,10 +13,13 @@ extern "C" {
 typedef struct KolibriAI KolibriAI;
 struct kolibri_config_t;
 
+#ifndef KOLIBRI_AI_SELFPLAY_CONFIG_DEFINED
+#define KOLIBRI_AI_SELFPLAY_CONFIG_DEFINED
 typedef struct {
     uint32_t tasks_per_iteration;
     uint32_t max_difficulty;
 } KolibriAISelfplayConfig;
+#endif
 
 typedef struct {
     KolibriSelfplayTask task;

--- a/include/util/config.h
+++ b/include/util/config.h
@@ -22,15 +22,29 @@ typedef struct {
     uint32_t trace_depth;
 } vm_config_t;
 
+#ifndef KOLIBRI_AI_PERSISTENCE_CONFIG_DEFINED
+#define KOLIBRI_AI_PERSISTENCE_CONFIG_DEFINED
 typedef struct {
+    char snapshot_path[256];
+    uint32_t snapshot_limit;
+} ai_persistence_config_t;
+#endif
 
+#ifndef KOLIBRI_AI_SELFPLAY_CONFIG_DEFINED
+#define KOLIBRI_AI_SELFPLAY_CONFIG_DEFINED
+typedef struct {
+    uint32_t tasks_per_iteration;
+    uint32_t max_difficulty;
+} KolibriAISelfplayConfig;
+#endif
 
 typedef struct {
     http_config_t http;
     vm_config_t vm;
-
-    uint32_t seed;
     ai_persistence_config_t ai;
+    KolibriAISelfplayConfig selfplay;
+    FormulaSearchConfig search;
+    uint32_t seed;
 } kolibri_config_t;
 
 int config_load(const char *path, kolibri_config_t *cfg);


### PR DESCRIPTION
## Summary
- define the AI persistence, self-play, and search configuration structs that `config.c` expects and aggregate them into `kolibri_config_t`
- guard the Kolibri AI header so the shared self-play configuration definition can be reused without redefinition warnings

## Testing
- cmake -S . -B build *(fails: missing json-c development package in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3424b38848323b7052da7e35e97bf