### PR TITLE
Add technical overview documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,3 +94,7 @@ The end-to-end development plan is captured in [`docs/roadmap.md`](docs/roadmap.
 ## Demo playbook
 
 For investor-grade demonstrations and product validation scenarios, consult [`docs/demos.md`](docs/demos.md). The playbook now outlines seventy-eight curated demos, associated KPIs, and exact launch instructions for Kolibri Studio and the public HTTP API.
+
+## Technical documentation
+
+For a subsystem-by-subsystem walkthrough of the runtime, storage, AI loop, HTTP shell, and tooling, read the [technical overview](docs/architecture.md). It links source files, configuration surfaces, and test harnesses so contributors can quickly orient themselves within the decimal-native codebase.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,64 @@
+# Kolibri Ω Technical Overview
+
+Kolibri Ω combines a compact decimal virtual machine, fractal key-value memory, a self-improving formula synthesizer, and a thin HTTP/web shell. This document walks through the codebase module by module so engineers, testers, and operators can navigate and extend the system with confidence.
+
+## Build and runtime pipeline
+- **Native toolchain.** `make build` compiles the C sources listed in the root `Makefile` into the `bin/kolibri_node` executable, linking pthread, JSON-C, math, UUID, OpenSSL crypto, and libcurl for networking and hashing support.【F:Makefile†L1-L38】
+- **Automated orchestration.** `kolibri.sh up` builds the native node, installs Vite/React dependencies, generates the static web bundle, and launches the node with logs streamed to `logs/kolibri.log`. The script also exposes `stop`, `bench`, and `clean` helpers for lifecycle management.【F:kolibri.sh†L1-L58】
+- **Configuration.** Runtime defaults live in `cfg/kolibri.jsonc`, defining HTTP listen parameters, VM execution limits, the PRNG seed, and AI snapshot persistence; the loader in `util/config.c` (referenced throughout the build targets) hydrates these values into `kolibri_config_t`.【F:cfg/kolibri.jsonc†L1-L22】【F:Makefile†L1-L38】
+
+## Native runtime architecture
+### Δ-VM v2 (`src/vm/vm.c`)
+- A stack-based interpreter accepts `prog_t` bytecode and enforces per-program gas (`max_steps`) and stack limits (`max_stack`) derived from `vm_limits_t`/`kolibri_config_t` (defaults 1024 steps, 128 stack slots).【F:src/vm/vm.c†L43-L72】
+- Implements decimal-focused opcodes: arithmetic (`ADD10`–`MOD10`), comparisons (`CMP`), control flow (`JZ`, `JNZ`, `CALL`, `RET`), persistence bridges (`READ_FKV`, `WRITE_FKV`), cryptographic primitives (`HASH10`), randomness (`RANDOM10`), and wall-clock sampling (`TIME10`), terminating with `HALT`. Errors surface as `vm_status_t` enums in `vm_result_t`.【F:src/vm/vm.c†L88-L220】
+- Optional tracing uses `vm_trace_t` to capture step-by-step opcode execution, stack tops, and gas consumption for debugging and UI visualization.【F:src/vm/vm.c†L20-L39】
+
+### Fractal Key-Value store (`src/fkv/fkv.c`)
+- A 10-ary trie guarded by a global mutex stores decimal digit keys and values, enabling prefix enumeration (`fkv_get_prefix`) and top-K collection with deterministic iteration order.【F:src/fkv/fkv.c†L11-L117】【F:src/fkv/fkv.c†L137-L176】
+- Persistence helpers serialize entries (key length, value length, payload, entry type) to disk (`fkv_save`) and rebuild the trie on load (`fkv_load`), allowing Kolibri AI and VM programs to survive restarts.【F:src/fkv/fkv.c†L208-L314】
+
+### Formula knowledge base (`include/formula.h`, `src/formula_runtime.c`, `src/formula_stub.c`)
+- `Formula` encapsulates both text and analytic representations with coefficients, metadata, and evaluation telemetry (PoE/MDL, rewards). Collections, datasets, and training pipelines provide unified management for AI-driven synthesis and reinforcement loops.【F:include/formula.h†L9-L120】
+- The training pipeline bundles candidate generation, dataset ingestion, lightweight MLP/transformer placeholders, and experience recording, giving the AI subsystem a consistent interface for future ML backends.【F:include/formula.h†L121-L192】
+
+### Kolibri AI orchestrator (`src/kolibri_ai.c`)
+- Maintains the global formula library, active training pipeline, reinforcement curriculum (`KolibriCurriculumState`), episodic dataset, and working memory facts with snapshot limits derived from config.【F:src/kolibri_ai.c†L21-L78】
+- Provides concurrency-safe dataset growth, curriculum normalization, reinforcement hooks, serialization helpers, and snapshot import/export to coordinate self-play tasks and network synchronization.【F:src/kolibri_ai.c†L80-L184】
+
+### Program synthesis utilities (`include/synthesis`) 
+- `FormulaSearchConfig` constrains enumeration (candidate counts, term limits, coefficient bounds). `formula_search_enumerate` walks the existing library and memory snapshot to emit new programs tailored to the curriculum state.【F:include/synthesis/search.h†L15-L32】
+- `synthesis/selfplay.h` (not shown here) defines task queues that feed `KolibriAISelfplayConfig`, allowing the AI loop to schedule evaluation runs proportionally to difficulty levels referenced by the orchestrator.【F:include/kolibri_ai.h†L21-L63】
+
+### Blockchain of knowledge (`src/blockchain.c`)
+- Maintains a growable array of validated blocks with ownership-tracked formula copies, capping the chain length and rehashing state with OpenSSL’s EVP SHA-256 helper to enforce a decimal difficulty target prefix (`"000"`).【F:src/blockchain.c†L1-L74】【F:src/blockchain.c†L87-L158】
+- Computes PoE/MDL-aware scores per formula, clones accepted entries into owned storage, and exposes chain management used by HTTP and synchronization layers.【F:src/blockchain.c†L37-L86】【F:src/blockchain.c†L158-L220】
+
+## Networking and surface area
+### HTTP server (`src/http/http_server.c`)
+- POSIX sockets plus worker threads accept requests, parse headers/body with size guards, and delegate to `http_handle_request`, honoring configuration caps like `max_body_size` from `kolibri_config_t`.【F:src/http/http_server.c†L1-L136】
+- Uses a producer/consumer queue (`client_task_t`) guarded by mutex/condition variables to distribute work across worker threads while supporting graceful stop signals.【F:src/http/http_server.c†L15-L63】【F:src/http/http_server.c†L137-L200】
+
+### HTTP routes (`src/http/http_routes.c`)
+- Exposes `/api/v1/health`, `/api/v1/metrics`, and `/api/v1/dialog` today, formatting JSON responses, tracking uptime, and wiring blockchain pointers for future expansions. Responses are heap-duplicated and freed by `http_response_free` to keep ownership explicit.【F:src/http/http_routes.c†L1-L90】【F:src/http/http_routes.c†L104-L148】
+
+### Web client (`web/`)
+- A Vite + React TypeScript SPA (`package.json`) bundles Kolibri Studio panels that consume the HTTP API. Build scripts `npm run build` and `vite preview` align with the automation baked into `kolibri.sh` for investor demos.【F:web/package.json†L1-L18】【F:kolibri.sh†L17-L37】
+
+## Configuration, persistence, and tooling
+- `kolibri_config_t` aggregates HTTP, VM, AI persistence, search, and self-play tunables so the node can spawn consistent subsystems across restarts. The config header intentionally mirrors the JSON layout for declarative overrides.【F:include/util/config.h†L1-L53】
+- AI snapshots (JSON) and F-KV dumps (binary) live under `data/`, while logs stream to `logs/`. The CLI cleans these directories via `kolibri.sh clean` when resetting state.【F:kolibri.sh†L1-L58】
+
+## Testing and validation
+- `make test` builds dedicated binaries for VM, F-KV, config parsing, and Kolibri AI iteration smoke tests, executing them sequentially to guard critical subsystems. Additional blockchain and integration harnesses reside in `tests/` for future automation stages.【F:Makefile†L40-L74】【F:tests†L1-L2】
+
+## Directory guide
+```
+include/    # Public headers for VM, F-KV, formulas, AI, synthesis, HTTP, utilities
+src/        # C implementations of runtime subsystems listed above
+cfg/        # JSONC configuration profiles loaded at startup
+web/        # Kolibri Studio SPA (React + Vite)
+docs/       # Product specs, roadmap, demos, and this technical overview
+tests/      # Unit and functional tests compiled by the Makefile targets
+```
+
+Armed with these cross-references, contributors can trace a feature from API call to VM opcode, update configuration defaults safely, and extend Kolibri Ω toward its decimal-native intelligence roadmap.


### PR DESCRIPTION
## Summary
- document the runtime, AI, blockchain, HTTP, and tooling subsystems in a new docs/architecture.md technical overview
- link the README to the new technical documentation so contributors can find it quickly

## Testing
- make test *(fails: existing build errors in formula and config headers)*

------
https://chatgpt.com/codex/tasks/task_e_68d34b9418688323aa46433782dfe2fe