### PR TITLE
Use json-c for AI snapshot serialization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ CC ?= gcc
 CFLAGS := -std=c11 -Wall -Wextra -O2 -Isrc -Iinclude -I/usr/include/json-c -pthread
 
 
-LDFLAGS := -lpthread -lm -luuid -lcrypto -lcurl
+LDFLAGS := -lpthread -lm -luuid -lcrypto -lcurl -ljson-c
 
 
 BUILD_DIR := build/obj
@@ -21,11 +21,9 @@ SRC := \
   src/http/http_server.c \
   src/http/http_routes.c \
   src/blockchain.c \
-
   src/formula_runtime.c \
   src/synthesis/search.c \
-  src/synthesis/formula_vm_eval.c
-
+  src/synthesis/formula_vm_eval.c \
   src/formula_stub.c \
   src/protocol/swarm.c
 
@@ -36,7 +34,8 @@ TEST_CONFIG_SRC := tests/unit/test_config.c src/util/config.c src/util/log.c
 
 TEST_KOLIBRI_ITER_SRC := tests/test_kolibri_ai_iterations.c src/kolibri_ai.c src/formula_runtime.c src/synthesis/search.c src/synthesis/formula_vm_eval.c src/vm/vm.c src/fkv/fkv.c
 
-TEST_KOLIBRI_ITER_SRC := tests/test_kolibri_ai_iterations.c src/kolibri_ai.c src/formula_runtime.c
+TEST_KOLIBRI_ITER_SRC := tests/test_kolibri_ai_iterations.c src/kolibri_ai.c src/formula_runtime.c src/synthesis/search.c
+TEST_KOLIBRI_STATE_SRC := tests/test_kolibri_ai_state.c src/kolibri_ai.c src/formula_stub.c src/synthesis/search.c
 TEST_SWARM_PROTOCOL_SRC := tests/unit/test_swarm_protocol.c src/protocol/swarm.c
 
 
@@ -66,11 +65,11 @@ run: build
 clean:
 	rm -rf $(BUILD_DIR) $(BIN_DIR) logs/* data/* web/node_modules web/dist
 
-.PHONY: test test-vm test-fkv test-config test-kolibri-ai test-http-routes bench clean run build
+.PHONY: test test-vm test-fkv test-config test-kolibri-ai test-kolibri-ai-state test-http-routes bench clean run build
 
 
 
-test: build test-vm test-fkv test-config test-kolibri-ai test-swarm-protocol
+test: build test-vm test-fkv test-config test-kolibri-ai test-kolibri-ai-state test-swarm-protocol
 
 
 $(BUILD_DIR)/tests/unit/test_vm: $(TEST_VM_SRC)
@@ -100,6 +99,13 @@ $(BUILD_DIR)/tests/test_kolibri_ai_iterations: $(TEST_KOLIBRI_ITER_SRC)
 	$(CC) $(CFLAGS) $(TEST_KOLIBRI_ITER_SRC) -o $@ $(LDFLAGS)
 
 test-kolibri-ai: $(BUILD_DIR)/tests/test_kolibri_ai_iterations
+	$<
+
+$(BUILD_DIR)/tests/test_kolibri_ai_state: $(TEST_KOLIBRI_STATE_SRC)
+	@mkdir -p $(BUILD_DIR)/tests
+	$(CC) $(CFLAGS) $(TEST_KOLIBRI_STATE_SRC) -o $@ $(LDFLAGS)
+
+test-kolibri-ai-state: $(BUILD_DIR)/tests/test_kolibri_ai_state
 	$<
 
 $(BUILD_DIR)/tests/unit/test_swarm_protocol: $(TEST_SWARM_PROTOCOL_SRC)

--- a/include/kolibri_ai.h
+++ b/include/kolibri_ai.h
@@ -99,7 +99,11 @@ Formula *kolibri_ai_get_best_formula(KolibriAI *ai);
 char *kolibri_ai_serialize_state(const KolibriAI *ai);
 char *kolibri_ai_serialize_formulas(const KolibriAI *ai, size_t max_results);
 
+/* Export the current AI state to a JSON document including formulas, dataset
+ * entries, and memory facts. Caller must free the returned string. */
 char *kolibri_ai_export_snapshot(const KolibriAI *ai);
+/* Import a snapshot previously produced by kolibri_ai_export_snapshot,
+ * restoring formulas, dataset entries, and memory facts. */
 int kolibri_ai_import_snapshot(KolibriAI *ai, const char *json);
 int kolibri_ai_sync_with_neighbor(KolibriAI *ai, const char *base_url);
 

--- a/tests/test_kolibri_ai_state.c
+++ b/tests/test_kolibri_ai_state.c
@@ -4,10 +4,14 @@
 #include "formula.h"
 
 #include <assert.h>
+#include <json-c/json.h>
+#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+
+#define EPSILON 1e-6
 
 static void ensure_contains(const char *json, const char *needle) {
     if (!json || !needle) {
@@ -19,10 +23,84 @@ static void ensure_contains(const char *json, const char *needle) {
     }
 }
 
+static int doubles_close(double a, double b) {
+    return fabs(a - b) < EPSILON;
+}
+
+static int dataset_entry_matches(struct json_object *entry,
+                                 const char *prompt,
+                                 const char *response,
+                                 double reward,
+                                 double poe,
+                                 double mdl) {
+    struct json_object *field = NULL;
+    const char *value = NULL;
+
+    if (!json_object_object_get_ex(entry, "prompt", &field)) {
+        return 0;
+    }
+    value = json_object_get_string(field);
+    if (!value || strcmp(value, prompt) != 0) {
+        return 0;
+    }
+
+    if (!json_object_object_get_ex(entry, "response", &field)) {
+        return 0;
+    }
+    value = json_object_get_string(field);
+    if (!value || strcmp(value, response) != 0) {
+        return 0;
+    }
+
+    if (!json_object_object_get_ex(entry, "reward", &field) ||
+        !doubles_close(json_object_get_double(field), reward)) {
+        return 0;
+    }
+    if (!json_object_object_get_ex(entry, "poe", &field) ||
+        !doubles_close(json_object_get_double(field), poe)) {
+        return 0;
+    }
+    if (!json_object_object_get_ex(entry, "mdl", &field) ||
+        !doubles_close(json_object_get_double(field), mdl)) {
+        return 0;
+    }
+    return 1;
+}
+
+static int memory_fact_matches(struct json_object *fact,
+                               const char *key,
+                               const char *value,
+                               double salience) {
+    struct json_object *field = NULL;
+    const char *text = NULL;
+
+    if (!json_object_object_get_ex(fact, "key", &field)) {
+        return 0;
+    }
+    text = json_object_get_string(field);
+    if (!text || strcmp(text, key) != 0) {
+        return 0;
+    }
+
+    if (!json_object_object_get_ex(fact, "value", &field)) {
+        return 0;
+    }
+    text = json_object_get_string(field);
+    if (!text || strcmp(text, value) != 0) {
+        return 0;
+    }
+
+    if (!json_object_object_get_ex(fact, "salience", &field)) {
+        return 0;
+    }
+    return doubles_close(json_object_get_double(field), salience);
+}
+
 int main(void) {
     kolibri_config_t cfg = {0};
     cfg.search = formula_search_config_default();
     cfg.search.max_candidates = 2;
+    cfg.ai.snapshot_limit = 4;
     KolibriAI *ai = kolibri_ai_create(&cfg);
     assert(ai != NULL);
 
@@ -42,6 +120,16 @@ int main(void) {
     experience.mdl = 0.05;
     assert(kolibri_ai_apply_reinforcement(ai, &formula, &experience) == 0);
 
+    KolibriAISelfplayInteraction interaction = {0};
+    strncpy(interaction.task.description,
+            "practice addition",
+            sizeof(interaction.task.description) - 1);
+    interaction.predicted_result = 0.42;
+    interaction.reward = 0.4;
+    interaction.task.expected_result = 0.37;
+    interaction.success = 1;
+    kolibri_ai_record_interaction(ai, &interaction);
+
     char *state = kolibri_ai_serialize_state(ai);
     assert(state != NULL);
     ensure_contains(state, "\"iterations\"");
@@ -51,12 +139,105 @@ int main(void) {
     ensure_contains(state, "\"recent_mdl\"");
     free(state);
 
-    char *formulas = kolibri_ai_serialize_formulas(ai, 3);
-    assert(formulas != NULL);
-    ensure_contains(formulas, "formulas");
-    ensure_contains(formulas, "kolibri");
-    free(formulas);
+    char *formulas_json = kolibri_ai_serialize_formulas(ai, 3);
+    assert(formulas_json != NULL);
+    ensure_contains(formulas_json, "formulas");
+    ensure_contains(formulas_json, "kolibri");
+    free(formulas_json);
 
+    char *snapshot = kolibri_ai_export_snapshot(ai);
+    assert(snapshot != NULL);
+
+    KolibriAI *clone = kolibri_ai_create(&cfg);
+    assert(clone != NULL);
+    assert(kolibri_ai_import_snapshot(clone, snapshot) == 0);
+    free(snapshot);
+
+    char *roundtrip = kolibri_ai_export_snapshot(clone);
+    assert(roundtrip != NULL);
+
+    struct json_object *root = json_tokener_parse(roundtrip);
+    assert(root != NULL);
+    assert(json_object_is_type(root, json_type_object));
+
+    struct json_object *formulas = NULL;
+    assert(json_object_object_get_ex(root, "formulas", &formulas));
+    assert(json_object_is_type(formulas, json_type_array));
+    int formula_found = 0;
+    size_t formula_len = json_object_array_length(formulas);
+    for (size_t i = 0; i < formula_len; ++i) {
+        struct json_object *item = json_object_array_get_idx(formulas, (int)i);
+        if (!item || !json_object_is_type(item, json_type_object)) {
+            continue;
+        }
+        struct json_object *id_obj = NULL;
+        struct json_object *eff_obj = NULL;
+        if (!json_object_object_get_ex(item, "id", &id_obj) ||
+            !json_object_object_get_ex(item, "effectiveness", &eff_obj)) {
+            continue;
+        }
+        const char *id = json_object_get_string(id_obj);
+        if (id && strcmp(id, "test.reinforce") == 0 &&
+            doubles_close(json_object_get_double(eff_obj), 0.8)) {
+            formula_found = 1;
+            break;
+        }
+    }
+    assert(formula_found);
+
+    struct json_object *dataset = NULL;
+    assert(json_object_object_get_ex(root, "dataset", &dataset));
+    assert(json_object_is_type(dataset, json_type_object));
+    struct json_object *entries = NULL;
+    assert(json_object_object_get_ex(dataset, "entries", &entries));
+    assert(json_object_is_type(entries, json_type_array));
+    int reinforce_entry = 0;
+    int interaction_entry = 0;
+    size_t entry_len = json_object_array_length(entries);
+    for (size_t i = 0; i < entry_len; ++i) {
+        struct json_object *entry = json_object_array_get_idx(entries, (int)i);
+        if (!entry || !json_object_is_type(entry, json_type_object)) {
+            continue;
+        }
+        if (dataset_entry_matches(entry, "1+1", "0.800", 0.8, 0.9, 0.05)) {
+            reinforce_entry = 1;
+        }
+        if (dataset_entry_matches(entry,
+                                  "practice addition",
+                                  "0.420",
+                                  0.4,
+                                  0.37,
+                                  0.0)) {
+            interaction_entry = 1;
+        }
+    }
+    assert(reinforce_entry);
+    assert(interaction_entry);
+
+    struct json_object *memory = NULL;
+    assert(json_object_object_get_ex(root, "memory", &memory));
+    assert(json_object_is_type(memory, json_type_object));
+    struct json_object *facts = NULL;
+    assert(json_object_object_get_ex(memory, "facts", &facts));
+    assert(json_object_is_type(facts, json_type_array));
+    int fact_found = 0;
+    size_t fact_len = json_object_array_length(facts);
+    for (size_t i = 0; i < fact_len; ++i) {
+        struct json_object *fact = json_object_array_get_idx(facts, (int)i);
+        if (!fact || !json_object_is_type(fact, json_type_object)) {
+            continue;
+        }
+        if (memory_fact_matches(fact, "test.reinforce", "1+1", 0.8)) {
+            fact_found = 1;
+            break;
+        }
+    }
+    assert(fact_found);
+
+    json_object_put(root);
+    free(roundtrip);
+    kolibri_ai_destroy(clone);
     kolibri_ai_destroy(ai);
     return 0;
 }
+


### PR DESCRIPTION
## Summary
- replace manual snapshot string building with json-c objects and arrays for formulas, dataset entries, and memory facts while respecting snapshot limits
- parse json-c snapshots to rebuild the in-memory dataset and memory module, and document the export/import contract in the public header
- add a regression test that round-trips an AI snapshot and verifies formulas, dataset entries, and memory facts survive the import

## Testing
- `make test-kolibri-ai-state`
- `make test-kolibri-ai`


------
https://chatgpt.com/codex/tasks/task_e_68d35d7845a083239074587238270f9b