### PR TITLE
Implement top-K FKV storage with scoring

### DIFF
--- a/cfg/kolibri.jsonc
+++ b/cfg/kolibri.jsonc
@@ -13,7 +13,9 @@
     "max_stack": 128,
     "trace_depth": 64
   },
-
+  // Top-K retention per trie node
+  "fkv": {
+    "top_k": 4
   },
   // PRNG seed for RANDOM10 opcode
   "seed": 1337,

--- a/include/fkv/fkv.h
+++ b/include/fkv/fkv.h
@@ -21,6 +21,7 @@ typedef struct {
     const uint8_t *value;
     size_t value_len;
     fkv_entry_type_t type;
+    double score;
 } fkv_entry_t;
 
 typedef struct {
@@ -30,7 +31,14 @@ typedef struct {
 
 int fkv_init(void);
 void fkv_shutdown(void);
-int fkv_put(const uint8_t *key, size_t kn, const uint8_t *val, size_t vn, fkv_entry_type_t type);
+void fkv_set_top_k(size_t top_k);
+size_t fkv_get_top_k(void);
+int fkv_put(const uint8_t *key,
+            size_t kn,
+            const uint8_t *val,
+            size_t vn,
+            fkv_entry_type_t type,
+            double score);
 int fkv_get_prefix(const uint8_t *key, size_t kn, fkv_iter_t *it, size_t k);
 void fkv_iter_free(fkv_iter_t *it);
 int fkv_save(const char *path);

--- a/include/util/config.h
+++ b/include/util/config.h
@@ -35,12 +35,17 @@ typedef struct {
 } KolibriAISelfplayConfig;
 
 typedef struct {
+    uint32_t top_k;
+} fkv_config_t;
+
+typedef struct {
     http_config_t http;
     vm_config_t vm;
     FormulaSearchConfig search;
     uint32_t seed;
     ai_persistence_config_t ai;
     KolibriAISelfplayConfig selfplay;
+    fkv_config_t fkv;
 } kolibri_config_t;
 
 int config_load(const char *path, kolibri_config_t *cfg);

--- a/src/fkv/fkv.c
+++ b/src/fkv/fkv.c
@@ -9,20 +9,38 @@
 #include <stdlib.h>
 #include <string.h>
 
-typedef struct fkv_node {
-    struct fkv_node *children[10];
+typedef struct fkv_payload {
     uint8_t *key;
     size_t key_len;
     uint8_t *value;
     size_t value_len;
     fkv_entry_type_t type;
+    double score;
+} fkv_payload_t;
+
+typedef struct fkv_node {
+    struct fkv_node *children[10];
+    fkv_payload_t *payload;
+    fkv_payload_t **top_entries;
+    size_t top_count;
+    size_t top_capacity;
 } fkv_node_t;
 
 static pthread_mutex_t fkv_lock = PTHREAD_MUTEX_INITIALIZER;
 static fkv_node_t *fkv_root = NULL;
+static size_t fkv_top_k_limit = 4;
 
 static fkv_node_t *node_create(void) {
     return calloc(1, sizeof(fkv_node_t));
+}
+
+static void payload_free(fkv_payload_t *payload) {
+    if (!payload) {
+        return;
+    }
+    free(payload->key);
+    free(payload->value);
+    free(payload);
 }
 
 static void node_free(fkv_node_t *node) {
@@ -32,9 +50,197 @@ static void node_free(fkv_node_t *node) {
     for (size_t i = 0; i < 10; ++i) {
         node_free(node->children[i]);
     }
-    free(node->key);
-    free(node->value);
+    payload_free(node->payload);
+    free(node->top_entries);
     free(node);
+}
+
+static fkv_payload_t *payload_create(const uint8_t *key,
+                                     size_t key_len,
+                                     const uint8_t *value,
+                                     size_t value_len,
+                                     fkv_entry_type_t type,
+                                     double score) {
+    fkv_payload_t *payload = calloc(1, sizeof(*payload));
+    if (!payload) {
+        return NULL;
+    }
+    if (key_len > 0) {
+        payload->key = malloc(key_len);
+        if (!payload->key) {
+            free(payload);
+            return NULL;
+        }
+        memcpy(payload->key, key, key_len);
+    }
+    if (value_len > 0) {
+        payload->value = malloc(value_len);
+        if (!payload->value) {
+            free(payload->key);
+            free(payload);
+            return NULL;
+        }
+        memcpy(payload->value, value, value_len);
+    }
+    payload->key_len = key_len;
+    payload->value_len = value_len;
+    payload->type = type;
+    payload->score = score;
+    return payload;
+}
+
+static int payload_update(fkv_payload_t *payload,
+                          const uint8_t *key,
+                          size_t key_len,
+                          const uint8_t *value,
+                          size_t value_len,
+                          fkv_entry_type_t type,
+                          double score) {
+    if (!payload) {
+        return -1;
+    }
+    int same_key = payload->key_len == key_len;
+    if (same_key && key_len > 0) {
+        same_key = memcmp(payload->key, key, key_len) == 0;
+    }
+    if (!same_key) {
+        uint8_t *new_key = NULL;
+        if (key_len > 0) {
+            new_key = malloc(key_len);
+            if (!new_key) {
+                return -1;
+            }
+            memcpy(new_key, key, key_len);
+        }
+        free(payload->key);
+        payload->key = new_key;
+        payload->key_len = key_len;
+    }
+
+    uint8_t *new_value = NULL;
+    if (value_len > 0) {
+        new_value = malloc(value_len);
+        if (!new_value) {
+            return -1;
+        }
+        memcpy(new_value, value, value_len);
+    }
+    free(payload->value);
+    payload->value = new_value;
+    payload->value_len = value_len;
+    payload->type = type;
+    payload->score = score;
+    return 0;
+}
+
+static int node_ensure_top_capacity(fkv_node_t *node, size_t limit) {
+    if (node->top_capacity == limit) {
+        return 0;
+    }
+    fkv_payload_t **entries = NULL;
+    if (limit > 0) {
+        entries = calloc(limit, sizeof(*entries));
+        if (!entries) {
+            return -1;
+        }
+    }
+    free(node->top_entries);
+    node->top_entries = entries;
+    node->top_capacity = limit;
+    if (node->top_count > limit) {
+        node->top_count = limit;
+    }
+    return 0;
+}
+
+static int payload_cmp_desc(const void *lhs, const void *rhs) {
+    const fkv_payload_t *a = *(const fkv_payload_t *const *)lhs;
+    const fkv_payload_t *b = *(const fkv_payload_t *const *)rhs;
+    if (a == b) {
+        return 0;
+    }
+    if (!a) {
+        return 1;
+    }
+    if (!b) {
+        return -1;
+    }
+    if (a->score > b->score) {
+        return -1;
+    }
+    if (a->score < b->score) {
+        return 1;
+    }
+    size_t min_len = a->key_len < b->key_len ? a->key_len : b->key_len;
+    if (min_len > 0) {
+        int cmp = memcmp(a->key, b->key, min_len);
+        if (cmp != 0) {
+            return cmp;
+        }
+    }
+    if (a->key_len < b->key_len) {
+        return -1;
+    }
+    if (a->key_len > b->key_len) {
+        return 1;
+    }
+    return 0;
+}
+
+static int node_recompute_top(fkv_node_t *node) {
+    if (!node) {
+        return 0;
+    }
+    size_t limit = fkv_top_k_limit ? fkv_top_k_limit : 1;
+    size_t capacity = 1 + 10 * limit;
+    if (capacity == 0) {
+        capacity = 1;
+    }
+    fkv_payload_t **candidates = calloc(capacity, sizeof(*candidates));
+    if (!candidates) {
+        return -1;
+    }
+    size_t count = 0;
+    if (node->payload) {
+        candidates[count++] = node->payload;
+    }
+    for (size_t i = 0; i < 10; ++i) {
+        fkv_node_t *child = node->children[i];
+        if (!child) {
+            continue;
+        }
+        for (size_t j = 0; j < child->top_count && count < capacity; ++j) {
+            candidates[count++] = child->top_entries[j];
+        }
+    }
+    qsort(candidates, count, sizeof(*candidates), payload_cmp_desc);
+
+    if (node_ensure_top_capacity(node, limit) != 0) {
+        free(candidates);
+        return -1;
+    }
+    size_t to_copy = count < limit ? count : limit;
+    for (size_t i = 0; i < to_copy; ++i) {
+        node->top_entries[i] = candidates[i];
+    }
+    for (size_t i = to_copy; i < limit; ++i) {
+        node->top_entries[i] = NULL;
+    }
+    node->top_count = to_copy;
+    free(candidates);
+    return 0;
+}
+
+static int recompute_subtree(fkv_node_t *node) {
+    if (!node) {
+        return 0;
+    }
+    for (size_t i = 0; i < 10; ++i) {
+        if (recompute_subtree(node->children[i]) != 0) {
+            return -1;
+        }
+    }
+    return node_recompute_top(node);
 }
 
 static int ensure_root_locked(void) {
@@ -48,46 +254,57 @@ static int fkv_put_locked(const uint8_t *key,
                           size_t kn,
                           const uint8_t *val,
                           size_t vn,
-                          fkv_entry_type_t type) {
+                          fkv_entry_type_t type,
+                          double score) {
     if (ensure_root_locked() != 0) {
         return -1;
     }
 
+    fkv_node_t **path = malloc((kn + 1) * sizeof(*path));
+    if (!path) {
+        return -1;
+    }
+
     fkv_node_t *node = fkv_root;
+    path[0] = node;
     for (size_t i = 0; i < kn; ++i) {
         uint8_t idx = key[i];
         if (idx > 9) {
+            free(path);
             return -1;
         }
         if (!node->children[idx]) {
             node->children[idx] = node_create();
             if (!node->children[idx]) {
+                free(path);
                 return -1;
             }
         }
         node = node->children[idx];
+        path[i + 1] = node;
     }
 
-    uint8_t *new_key = malloc(kn);
-    uint8_t *new_value = malloc(vn);
-    if (!new_key || !new_value) {
-        free(new_key);
-        free(new_value);
+    if (!node->payload) {
+        node->payload = payload_create(key, kn, val, vn, type, score);
+        if (!node->payload) {
+            free(path);
+            return -1;
+        }
+    } else if (payload_update(node->payload, key, kn, val, vn, type, score) != 0) {
+        free(path);
         return -1;
     }
-    memcpy(new_key, key, kn);
-    memcpy(new_value, val, vn);
 
-    free(node->key);
-    free(node->value);
+    int rc = 0;
+    size_t depth = kn + 1;
+    for (size_t i = depth; i-- > 0;) {
+        if (node_recompute_top(path[i]) != 0) {
+            rc = -1;
+        }
+    }
 
-    node->key = new_key;
-    node->key_len = kn;
-    node->value = new_value;
-    node->value_len = vn;
-    node->type = type;
-
-    return 0;
+    free(path);
+    return rc;
 }
 
 int fkv_init(void) {
@@ -108,35 +325,35 @@ int fkv_put(const uint8_t *key,
             size_t kn,
             const uint8_t *val,
             size_t vn,
-            fkv_entry_type_t type) {
+            fkv_entry_type_t type,
+            double score) {
     if (!key || !val || kn == 0 || vn == 0) {
         return -1;
     }
 
     pthread_mutex_lock(&fkv_lock);
-    int rc = fkv_put_locked(key, kn, val, vn, type);
+    int rc = fkv_put_locked(key, kn, val, vn, type, score);
     pthread_mutex_unlock(&fkv_lock);
     return rc;
 }
 
-static void collect_entries(const fkv_node_t *node,
-                            fkv_entry_t *entries,
-                            size_t *count,
-                            size_t limit) {
-    if (!node || *count >= limit) {
-        return;
+void fkv_set_top_k(size_t top_k) {
+    size_t limit = top_k == 0 ? 1 : top_k;
+    pthread_mutex_lock(&fkv_lock);
+    if (fkv_top_k_limit != limit) {
+        fkv_top_k_limit = limit;
+        if (fkv_root) {
+            recompute_subtree(fkv_root);
+        }
     }
-    if (node->value && *count < limit) {
-        entries[*count].key = node->key;
-        entries[*count].key_len = node->key_len;
-        entries[*count].value = node->value;
-        entries[*count].value_len = node->value_len;
-        entries[*count].type = node->type;
-        (*count)++;
-    }
-    for (size_t i = 0; i < 10 && *count < limit; ++i) {
-        collect_entries(node->children[i], entries, count, limit);
-    }
+    pthread_mutex_unlock(&fkv_lock);
+}
+
+size_t fkv_get_top_k(void) {
+    pthread_mutex_lock(&fkv_lock);
+    size_t limit = fkv_top_k_limit;
+    pthread_mutex_unlock(&fkv_lock);
+    return limit;
 }
 
 int fkv_get_prefix(const uint8_t *key, size_t kn, fkv_iter_t *it, size_t k) {
@@ -166,19 +383,37 @@ int fkv_get_prefix(const uint8_t *key, size_t kn, fkv_iter_t *it, size_t k) {
         }
     }
 
-    size_t limit = k ? k : 1;
+    size_t limit = k ? k : fkv_top_k_limit;
+    if (limit > node->top_count) {
+        limit = node->top_count;
+    }
+    if (limit == 0) {
+        pthread_mutex_unlock(&fkv_lock);
+        return 0;
+    }
+
     fkv_entry_t *entries = calloc(limit, sizeof(fkv_entry_t));
     if (!entries) {
         pthread_mutex_unlock(&fkv_lock);
         return -1;
     }
 
-    size_t count = 0;
-    collect_entries(node, entries, &count, limit);
+    for (size_t i = 0; i < limit; ++i) {
+        fkv_payload_t *payload = node->top_entries[i];
+        if (!payload) {
+            continue;
+        }
+        entries[i].key = payload->key;
+        entries[i].key_len = payload->key_len;
+        entries[i].value = payload->value;
+        entries[i].value_len = payload->value_len;
+        entries[i].type = payload->type;
+        entries[i].score = payload->score;
+    }
     pthread_mutex_unlock(&fkv_lock);
 
     it->entries = entries;
-    it->count = count;
+    it->count = limit;
     return 0;
 }
 
@@ -195,7 +430,7 @@ static void count_entries(const fkv_node_t *node, size_t *count) {
     if (!node) {
         return;
     }
-    if (node->value) {
+    if (node->payload) {
         (*count)++;
     }
     for (size_t i = 0; i < 10; ++i) {
@@ -207,23 +442,27 @@ static int serialize_node(FILE *fp, const fkv_node_t *node) {
     if (!node) {
         return 0;
     }
-    if (node->value) {
-        uint64_t key_len = node->key_len;
-        uint64_t value_len = node->value_len;
-        uint8_t type = (uint8_t)node->type;
+    if (node->payload) {
+        uint64_t key_len = node->payload->key_len;
+        uint64_t value_len = node->payload->value_len;
+        uint8_t type = (uint8_t)node->payload->type;
+        double score = node->payload->score;
         if (fwrite(&key_len, sizeof(key_len), 1, fp) != 1) {
             return -1;
         }
-        if (key_len && fwrite(node->key, 1, key_len, fp) != key_len) {
+        if (key_len && fwrite(node->payload->key, 1, key_len, fp) != key_len) {
             return -1;
         }
         if (fwrite(&value_len, sizeof(value_len), 1, fp) != 1) {
             return -1;
         }
-        if (value_len && fwrite(node->value, 1, value_len, fp) != value_len) {
+        if (value_len && fwrite(node->payload->value, 1, value_len, fp) != value_len) {
             return -1;
         }
         if (fwrite(&type, sizeof(type), 1, fp) != 1) {
+            return -1;
+        }
+        if (fwrite(&score, sizeof(score), 1, fp) != 1) {
             return -1;
         }
     }
@@ -300,6 +539,7 @@ int fkv_load(const char *path) {
         uint64_t key_len = 0;
         uint64_t value_len = 0;
         uint8_t type = 0;
+        double score = 0.0;
 
         if (fread(&key_len, sizeof(key_len), 1, fp) != 1) {
             rc = -1;
@@ -338,7 +578,19 @@ int fkv_load(const char *path) {
             break;
         }
 
-        if (fkv_put(key_buf, (size_t)key_len, value_buf, (size_t)value_len, (fkv_entry_type_t)type) != 0) {
+        if (fread(&score, sizeof(score), 1, fp) != 1) {
+            free(key_buf);
+            free(value_buf);
+            rc = -1;
+            break;
+        }
+
+        if (fkv_put(key_buf,
+                    (size_t)key_len,
+                    value_buf,
+                    (size_t)value_len,
+                    (fkv_entry_type_t)type,
+                    score) != 0) {
             free(key_buf);
             free(value_buf);
             rc = -1;

--- a/src/main.c
+++ b/src/main.c
@@ -278,7 +278,12 @@ static int run_chat(const kolibri_config_t *cfg) {
             int stored = 0;
             if (digits_from_number(exchange_id, key_digits, sizeof(key_digits), &key_len) == 0 &&
                 digits_from_number(value, val_digits, sizeof(val_digits), &val_len) == 0) {
-                if (fkv_put(key_digits, key_len, val_digits, val_len, FKV_ENTRY_TYPE_VALUE) == 0) {
+                if (fkv_put(key_digits,
+                             key_len,
+                             val_digits,
+                             val_len,
+                             FKV_ENTRY_TYPE_VALUE,
+                             1.0) == 0) {
                     stored = 1;
                 }
             }
@@ -323,6 +328,8 @@ int main(int argc, char **argv) {
     if (config_load("cfg/kolibri.jsonc", &cfg) != 0) {
         log_warn("could not read cfg/kolibri.jsonc, using defaults");
     }
+
+    fkv_set_top_k(cfg.fkv.top_k);
 
     if (argc > 1 && strcmp(argv[1], "--bench") == 0) {
         if (log_fp) {

--- a/src/util/config.c
+++ b/src/util/config.c
@@ -23,6 +23,8 @@ static void set_defaults(kolibri_config_t *cfg) {
     cfg->vm.max_stack = 128;
     cfg->vm.trace_depth = 64;
 
+    cfg->fkv.top_k = 4;
+
     cfg->seed = 1337;
 
     strncpy(cfg->ai.snapshot_path,
@@ -429,6 +431,48 @@ static int parse_ai_object(json_cursor_t *cur, kolibri_config_t *cfg) {
     return -1;
 }
 
+static int parse_fkv_object(json_cursor_t *cur, kolibri_config_t *cfg) {
+    if (consume_char(cur, '{') != 0) {
+        return -1;
+    }
+    while (*cur->cur) {
+        skip_ws(cur);
+        if (*cur->cur == '}') {
+            cur->cur++;
+            return 0;
+        }
+        char key[32];
+        if (parse_string(cur, key, sizeof(key)) != 0) {
+            return -1;
+        }
+        if (consume_char(cur, ':') != 0) {
+            return -1;
+        }
+        if (strcmp(key, "top_k") == 0) {
+            uint64_t value = 0;
+            if (parse_uint(cur, &value) != 0 || value == 0 || value > UINT32_MAX) {
+                return -1;
+            }
+            cfg->fkv.top_k = (uint32_t)value;
+        } else {
+            if (skip_value(cur) != 0) {
+                return -1;
+            }
+        }
+        skip_ws(cur);
+        if (*cur->cur == ',') {
+            cur->cur++;
+            continue;
+        }
+        if (*cur->cur == '}') {
+            cur->cur++;
+            return 0;
+        }
+        return -1;
+    }
+    return -1;
+}
+
 static int parse_selfplay_object(json_cursor_t *cur, kolibri_config_t *cfg) {
     if (consume_char(cur, '{') != 0) {
         return -1;
@@ -657,6 +701,12 @@ int config_load(const char *path, kolibri_config_t *cfg) {
             saw_seed = 1;
         } else if (strcmp(key, "ai") == 0) {
             if (parse_ai_object(&cur, &tmp) != 0) {
+                free(buffer);
+                errno = EINVAL;
+                return -1;
+            }
+        } else if (strcmp(key, "fkv") == 0) {
+            if (parse_fkv_object(&cur, &tmp) != 0) {
                 free(buffer);
                 errno = EINVAL;
                 return -1;

--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -309,7 +309,12 @@ int vm_run(const prog_t *p, const vm_limits_t *lim, vm_trace_t *trace, vm_result
                 status = VM_ERR_INVALID_OPCODE;
                 goto done;
             }
-            fkv_put(key_digits, key_len, value_digits, value_len, FKV_ENTRY_TYPE_VALUE);
+            fkv_put(key_digits,
+                    key_len,
+                    value_digits,
+                    value_len,
+                    FKV_ENTRY_TYPE_VALUE,
+                    0.0);
             break;
         }
         case 0x0E: { // HASH10

--- a/tests/unit/test_config.c
+++ b/tests/unit/test_config.c
@@ -43,6 +43,9 @@ static void test_config_valid(void) {
         "    \"max_stack\": 256,\n"
         "    \"trace_depth\": 32\n"
         "  },\n"
+        "  \"fkv\": {\n"
+        "    \"top_k\": 7\n"
+        "  },\n"
         "  \"seed\": 777\n"
         "}\n";
 
@@ -55,6 +58,7 @@ static void test_config_valid(void) {
     assert(cfg.vm.max_steps == 4096);
     assert(cfg.vm.max_stack == 256);
     assert(cfg.vm.trace_depth == 32);
+    assert(cfg.fkv.top_k == 7);
     assert(cfg.seed == 777);
     remove_temp_file(path);
 }
@@ -79,6 +83,7 @@ static void test_config_missing_field(void) {
     assert(cfg.vm.max_steps == 2048);
     assert(cfg.vm.max_stack == 128);
     assert(cfg.vm.trace_depth == 64);
+    assert(cfg.fkv.top_k == 4);
     assert(cfg.seed == 1337);
     remove_temp_file(path);
 }
@@ -92,6 +97,7 @@ static void test_config_invalid_json(void) {
     assert(errno == EINVAL);
     assert(strcmp(cfg.http.host, "0.0.0.0") == 0);
     assert(cfg.http.port == 9000);
+    assert(cfg.fkv.top_k == 4);
     remove_temp_file(path);
 }
 

--- a/tests/unit/test_fkv.c
+++ b/tests/unit/test_fkv.c
@@ -4,12 +4,16 @@
 
 #include <assert.h>
 #include <fcntl.h>
+#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 
-static void insert_sample(const char *key_str, const char *val_str, fkv_entry_type_t type) {
+static void insert_sample(const char *key_str,
+                          const char *val_str,
+                          fkv_entry_type_t type,
+                          double score) {
     size_t klen = strlen(key_str);
     size_t vlen = strlen(val_str);
     uint8_t *kbuf = malloc(klen);
@@ -20,7 +24,7 @@ static void insert_sample(const char *key_str, const char *val_str, fkv_entry_ty
     for (size_t i = 0; i < vlen; ++i) {
         vbuf[i] = (uint8_t)(val_str[i] - '0');
     }
-    assert(fkv_put(kbuf, klen, vbuf, vlen, type) == 0);
+    assert(fkv_put(kbuf, klen, vbuf, vlen, type, score) == 0);
     free(kbuf);
     free(vbuf);
 }
@@ -34,34 +38,38 @@ static void create_temp_snapshot(char *buffer, size_t buffer_size, const char *t
 }
 
 static void test_prefix(void) {
+    fkv_set_top_k(3);
     fkv_init();
-    insert_sample("123", "45", FKV_ENTRY_TYPE_VALUE);
-    insert_sample("124", "67", FKV_ENTRY_TYPE_VALUE);
-    insert_sample("129", "89", FKV_ENTRY_TYPE_VALUE);
-    insert_sample("880", "987654", FKV_ENTRY_TYPE_PROGRAM);
+    insert_sample("123", "45", FKV_ENTRY_TYPE_VALUE, 0.9);
+    insert_sample("124", "67", FKV_ENTRY_TYPE_VALUE, 0.5);
+    insert_sample("129", "89", FKV_ENTRY_TYPE_VALUE, 0.7);
+    insert_sample("880", "987654", FKV_ENTRY_TYPE_PROGRAM, 0.2);
 
     uint8_t prefix[] = {1, 2};
     fkv_iter_t it = {0};
     assert(fkv_get_prefix(prefix, sizeof(prefix), &it, 3) == 0);
-    assert(it.count >= 2);
-    for (size_t i = 0; i < it.count; ++i) {
-        assert(it.entries[i].key_len >= 2);
-        assert(it.entries[i].type == FKV_ENTRY_TYPE_VALUE);
-    }
+    assert(it.count == 3);
+    assert(it.entries[0].type == FKV_ENTRY_TYPE_VALUE);
+    assert(it.entries[1].type == FKV_ENTRY_TYPE_VALUE);
+    assert(it.entries[2].type == FKV_ENTRY_TYPE_VALUE);
+    assert(it.entries[0].score >= it.entries[1].score);
+    assert(it.entries[1].score >= it.entries[2].score);
     fkv_iter_free(&it);
 
     uint8_t program_prefix[] = {8, 8};
     assert(fkv_get_prefix(program_prefix, sizeof(program_prefix), &it, 2) == 0);
     assert(it.count == 1);
     assert(it.entries[0].type == FKV_ENTRY_TYPE_PROGRAM);
+    assert(fabs(it.entries[0].score - 0.2) < 1e-9);
     fkv_iter_free(&it);
     fkv_shutdown();
 }
 
 static void test_serialization_roundtrip(void) {
+    fkv_set_top_k(2);
     fkv_init();
-    insert_sample("123", "45", FKV_ENTRY_TYPE_VALUE);
-    insert_sample("555", "99", FKV_ENTRY_TYPE_VALUE);
+    insert_sample("123", "45", FKV_ENTRY_TYPE_VALUE, 0.4);
+    insert_sample("555", "99", FKV_ENTRY_TYPE_VALUE, 0.6);
 
     char snapshot[128];
     create_temp_snapshot(snapshot, sizeof(snapshot), "fkv_snapshot_roundtrip");
@@ -77,12 +85,14 @@ static void test_serialization_roundtrip(void) {
     assert(it.count == 1);
     assert(it.entries[0].value_len == 2);
     assert(memcmp(it.entries[0].value, (uint8_t[]){4, 5}, 2) == 0);
+    assert(fabs(it.entries[0].score - 0.4) < 1e-9);
     fkv_iter_free(&it);
 
     uint8_t key555[] = {5, 5, 5};
     assert(fkv_get_prefix(key555, sizeof(key555), &it, 1) == 0);
     assert(it.count == 1);
     assert(memcmp(it.entries[0].value, (uint8_t[]){9, 9}, 2) == 0);
+    assert(fabs(it.entries[0].score - 0.6) < 1e-9);
     fkv_iter_free(&it);
 
     fkv_shutdown();
@@ -91,8 +101,9 @@ static void test_serialization_roundtrip(void) {
 }
 
 static void test_load_overwrites_existing(void) {
+    fkv_set_top_k(1);
     fkv_init();
-    insert_sample("123", "45", FKV_ENTRY_TYPE_VALUE);
+    insert_sample("123", "45", FKV_ENTRY_TYPE_VALUE, 1.0);
 
     char snapshot[128];
     create_temp_snapshot(snapshot, sizeof(snapshot), "fkv_snapshot_overwrite");
@@ -100,7 +111,7 @@ static void test_load_overwrites_existing(void) {
     fkv_shutdown();
 
     fkv_init();
-    insert_sample("999", "11", FKV_ENTRY_TYPE_VALUE);
+    insert_sample("999", "11", FKV_ENTRY_TYPE_VALUE, 0.5);
     assert(fkv_load(snapshot) == 0);
 
     uint8_t key999[] = {9, 9, 9};
@@ -117,10 +128,41 @@ static void test_load_overwrites_existing(void) {
     unlink(snapshot);
 }
 
+static void test_topk_enforcement(void) {
+    fkv_set_top_k(3);
+    fkv_init();
+    const char *keys[] = {"4200", "4201", "4202", "4203", "4204"};
+    const double scores[] = {0.1, 0.9, 0.5, 0.7, 0.3};
+    for (size_t i = 0; i < sizeof(keys) / sizeof(keys[0]); ++i) {
+        insert_sample(keys[i], "1", FKV_ENTRY_TYPE_VALUE, scores[i]);
+    }
+
+    uint8_t prefix[] = {4, 2};
+    fkv_iter_t it = {0};
+    assert(fkv_get_prefix(prefix, sizeof(prefix), &it, 0) == 0);
+    assert(it.count == 3);
+
+    static const uint8_t expected_keys[][4] = {
+        {4, 2, 0, 1},
+        {4, 2, 0, 3},
+        {4, 2, 0, 2},
+    };
+    const double expected_scores[] = {0.9, 0.7, 0.5};
+    for (size_t i = 0; i < it.count; ++i) {
+        assert(it.entries[i].key_len == 4);
+        assert(memcmp(it.entries[i].key, expected_keys[i], 4) == 0);
+        assert(fabs(it.entries[i].score - expected_scores[i]) < 1e-9);
+    }
+
+    fkv_iter_free(&it);
+    fkv_shutdown();
+}
+
 int main(void) {
     test_prefix();
     test_serialization_roundtrip();
     test_load_overwrites_existing();
+    test_topk_enforcement();
     printf("fkv tests passed\n");
     return 0;
 }


### PR DESCRIPTION
## Summary
- redesign F-KV trie nodes to maintain scored payloads and aggregated top-K lists per prefix
- persist score metadata, update APIs to accept scores, and wire configuration for the global top-K limit
- extend unit coverage for top-K ordering and config defaults

## Testing
- /tmp/test_fkv
- /tmp/test_config

------
https://chatgpt.com/codex/tasks/task_e_68d35e3a831c8323b71194d68e7d907f