### PR TITLE
Fix kolibri config and enable make tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,11 +21,9 @@ SRC := \
   src/http/http_server.c \
   src/http/http_routes.c \
   src/blockchain.c \
-
   src/formula_runtime.c \
   src/synthesis/search.c \
-  src/synthesis/formula_vm_eval.c
-
+  src/synthesis/formula_vm_eval.c \
   src/formula_stub.c \
   src/protocol/swarm.c
 

--- a/cfg/kolibri.jsonc
+++ b/cfg/kolibri.jsonc
@@ -13,8 +13,6 @@
     "max_stack": 128,
     "trace_depth": 64
   },
-
-  },
   // PRNG seed for RANDOM10 opcode
   "seed": 1337,
   // Kolibri AI persistence


### PR DESCRIPTION
## Summary
- remove the stray closing brace from cfg/kolibri.jsonc so the root keys form valid JSONC
- clean up the Makefile source list and command indentation so GNU Make targets can run

## Testing
- make test-config

------
https://chatgpt.com/codex/tasks/task_e_68d35fab28c88323ba7924ba14983c4c