### PR TITLE
Refine F-KV to maintain top-K entries

### DIFF
--- a/cfg/kolibri.jsonc
+++ b/cfg/kolibri.jsonc
@@ -1,5 +1,4 @@
 // Copyright (c) 2024 Кочуров Владислав Евгеньевич
-
 {
   // HTTP configuration
   "http": {
@@ -13,7 +12,9 @@
     "max_stack": 128,
     "trace_depth": 64
   },
-
+  // F-KV storage defaults
+  "fkv": {
+    "top_k": 8
   },
   // PRNG seed for RANDOM10 opcode
   "seed": 1337,

--- a/include/fkv/fkv.h
+++ b/include/fkv/fkv.h
@@ -21,6 +21,7 @@ typedef struct {
     const uint8_t *value;
     size_t value_len;
     fkv_entry_type_t type;
+    double score;
 } fkv_entry_t;
 
 typedef struct {
@@ -28,9 +29,15 @@ typedef struct {
     size_t count;
 } fkv_iter_t;
 
-int fkv_init(void);
+int fkv_init(size_t top_k_limit);
 void fkv_shutdown(void);
-int fkv_put(const uint8_t *key, size_t kn, const uint8_t *val, size_t vn, fkv_entry_type_t type);
+size_t fkv_get_top_k_limit(void);
+int fkv_put(const uint8_t *key,
+            size_t kn,
+            const uint8_t *val,
+            size_t vn,
+            fkv_entry_type_t type,
+            double score);
 int fkv_get_prefix(const uint8_t *key, size_t kn, fkv_iter_t *it, size_t k);
 void fkv_iter_free(fkv_iter_t *it);
 int fkv_save(const char *path);

--- a/include/util/config.h
+++ b/include/util/config.h
@@ -35,12 +35,17 @@ typedef struct {
 } KolibriAISelfplayConfig;
 
 typedef struct {
+    uint32_t top_k;
+} fkv_config_t;
+
+typedef struct {
     http_config_t http;
     vm_config_t vm;
     FormulaSearchConfig search;
     uint32_t seed;
     ai_persistence_config_t ai;
     KolibriAISelfplayConfig selfplay;
+    fkv_config_t fkv;
 } kolibri_config_t;
 
 int config_load(const char *path, kolibri_config_t *cfg);

--- a/src/fkv/fkv.c
+++ b/src/fkv/fkv.c
@@ -3,26 +3,47 @@
 #include "fkv/fkv.h"
 
 #include <errno.h>
+#include <math.h>
 #include <pthread.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-typedef struct fkv_node {
-    struct fkv_node *children[10];
+typedef struct fkv_entry_payload {
     uint8_t *key;
     size_t key_len;
     uint8_t *value;
     size_t value_len;
     fkv_entry_type_t type;
+    double score;
+} fkv_entry_payload_t;
+
+typedef struct fkv_node {
+    struct fkv_node *children[10];
+    fkv_entry_payload_t *payload;
+    fkv_entry_payload_t **top_entries;
+    size_t top_count;
+    size_t top_capacity;
 } fkv_node_t;
 
 static pthread_mutex_t fkv_lock = PTHREAD_MUTEX_INITIALIZER;
 static fkv_node_t *fkv_root = NULL;
+static size_t fkv_top_k_limit_value = 8;
+static const size_t FKV_DEFAULT_TOP_K = 8;
+static const size_t FKV_MAX_TOP_K = 1024;
 
 static fkv_node_t *node_create(void) {
     return calloc(1, sizeof(fkv_node_t));
+}
+
+static void payload_destroy(fkv_entry_payload_t *payload) {
+    if (!payload) {
+        return;
+    }
+    free(payload->key);
+    free(payload->value);
+    free(payload);
 }
 
 static void node_free(fkv_node_t *node) {
@@ -32,8 +53,8 @@ static void node_free(fkv_node_t *node) {
     for (size_t i = 0; i < 10; ++i) {
         node_free(node->children[i]);
     }
-    free(node->key);
-    free(node->value);
+    payload_destroy(node->payload);
+    free(node->top_entries);
     free(node);
 }
 
@@ -44,54 +65,209 @@ static int ensure_root_locked(void) {
     return fkv_root ? 0 : -1;
 }
 
+static int node_reserve_top(fkv_node_t *node, size_t capacity) {
+    if (!node || capacity == 0) {
+        return 0;
+    }
+    if (node->top_capacity >= capacity) {
+        return 0;
+    }
+    fkv_entry_payload_t **entries =
+        realloc(node->top_entries, capacity * sizeof(*entries));
+    if (!entries) {
+        return -1;
+    }
+    node->top_entries = entries;
+    node->top_capacity = capacity;
+    return 0;
+}
+
+static int compare_payloads(const void *lhs, const void *rhs) {
+    const fkv_entry_payload_t *a = *(const fkv_entry_payload_t *const *)lhs;
+    const fkv_entry_payload_t *b = *(const fkv_entry_payload_t *const *)rhs;
+    if (a->score < b->score) {
+        return 1;
+    }
+    if (a->score > b->score) {
+        return -1;
+    }
+    size_t min_len = a->key_len < b->key_len ? a->key_len : b->key_len;
+    int cmp = memcmp(a->key, b->key, min_len);
+    if (cmp != 0) {
+        return cmp;
+    }
+    if (a->key_len < b->key_len) {
+        return -1;
+    }
+    if (a->key_len > b->key_len) {
+        return 1;
+    }
+    return 0;
+}
+
+static int node_update_top(fkv_node_t *node) {
+    if (!node) {
+        return 0;
+    }
+    size_t limit = fkv_top_k_limit_value;
+    if (limit == 0) {
+        node->top_count = 0;
+        return 0;
+    }
+
+    size_t candidate_capacity = 1 + 10 * limit;
+    fkv_entry_payload_t **candidates =
+        malloc(candidate_capacity * sizeof(*candidates));
+    if (!candidates) {
+        return -1;
+    }
+    size_t count = 0;
+    if (node->payload) {
+        candidates[count++] = node->payload;
+    }
+    for (size_t i = 0; i < 10; ++i) {
+        fkv_node_t *child = node->children[i];
+        if (!child) {
+            continue;
+        }
+        for (size_t j = 0; j < child->top_count && count < candidate_capacity; ++j) {
+            candidates[count++] = child->top_entries[j];
+        }
+    }
+
+    if (count == 0) {
+        node->top_count = 0;
+        free(candidates);
+        return 0;
+    }
+
+    qsort(candidates, count, sizeof(*candidates), compare_payloads);
+
+    if (node_reserve_top(node, limit) != 0) {
+        free(candidates);
+        return -1;
+    }
+
+    size_t new_count = count < limit ? count : limit;
+    for (size_t i = 0; i < new_count; ++i) {
+        node->top_entries[i] = candidates[i];
+    }
+    node->top_count = new_count;
+
+    free(candidates);
+    return 0;
+}
+
+static int node_set_payload(fkv_node_t *node,
+                            const uint8_t *key,
+                            size_t key_len,
+                            const uint8_t *value,
+                            size_t value_len,
+                            fkv_entry_type_t type,
+                            double score) {
+    if (!node) {
+        return -1;
+    }
+
+    fkv_entry_payload_t *payload = node->payload;
+    int created = 0;
+    if (!payload) {
+        payload = calloc(1, sizeof(*payload));
+        if (!payload) {
+            return -1;
+        }
+        node->payload = payload;
+        created = 1;
+    }
+
+    uint8_t *key_copy = malloc(key_len);
+    uint8_t *value_copy = malloc(value_len);
+    if (!key_copy || !value_copy) {
+        free(key_copy);
+        free(value_copy);
+        if (created) {
+            payload_destroy(payload);
+            node->payload = NULL;
+        }
+        return -1;
+    }
+
+    memcpy(key_copy, key, key_len);
+    memcpy(value_copy, value, value_len);
+
+    free(payload->key);
+    free(payload->value);
+
+    payload->key = key_copy;
+    payload->key_len = key_len;
+    payload->value = value_copy;
+    payload->value_len = value_len;
+    payload->type = type;
+    payload->score = score;
+
+    return 0;
+}
+
 static int fkv_put_locked(const uint8_t *key,
                           size_t kn,
                           const uint8_t *val,
                           size_t vn,
-                          fkv_entry_type_t type) {
+                          fkv_entry_type_t type,
+                          double score) {
     if (ensure_root_locked() != 0) {
         return -1;
     }
 
+    fkv_node_t **path = calloc(kn + 1, sizeof(*path));
+    if (!path) {
+        return -1;
+    }
+
     fkv_node_t *node = fkv_root;
+    path[0] = node;
     for (size_t i = 0; i < kn; ++i) {
         uint8_t idx = key[i];
         if (idx > 9) {
+            free(path);
             return -1;
         }
         if (!node->children[idx]) {
             node->children[idx] = node_create();
             if (!node->children[idx]) {
+                free(path);
                 return -1;
             }
         }
         node = node->children[idx];
+        path[i + 1] = node;
     }
 
-    uint8_t *new_key = malloc(kn);
-    uint8_t *new_value = malloc(vn);
-    if (!new_key || !new_value) {
-        free(new_key);
-        free(new_value);
-        return -1;
+    int rc = node_set_payload(node, key, kn, val, vn, type, score);
+    if (rc == 0) {
+        for (size_t i = kn + 1; i-- > 0;) {
+            if (node_update_top(path[i]) != 0) {
+                rc = -1;
+                break;
+            }
+        }
     }
-    memcpy(new_key, key, kn);
-    memcpy(new_value, val, vn);
 
-    free(node->key);
-    free(node->value);
-
-    node->key = new_key;
-    node->key_len = kn;
-    node->value = new_value;
-    node->value_len = vn;
-    node->type = type;
-
-    return 0;
+    free(path);
+    return rc;
 }
 
-int fkv_init(void) {
+int fkv_init(size_t top_k_limit) {
+    if (top_k_limit == 0) {
+        top_k_limit = FKV_DEFAULT_TOP_K;
+    }
+    if (top_k_limit > FKV_MAX_TOP_K) {
+        top_k_limit = FKV_MAX_TOP_K;
+    }
+
     pthread_mutex_lock(&fkv_lock);
+    node_free(fkv_root);
+    fkv_root = NULL;
+    fkv_top_k_limit_value = top_k_limit;
     int rc = ensure_root_locked();
     pthread_mutex_unlock(&fkv_lock);
     return rc;
@@ -104,39 +280,27 @@ void fkv_shutdown(void) {
     pthread_mutex_unlock(&fkv_lock);
 }
 
+size_t fkv_get_top_k_limit(void) {
+    pthread_mutex_lock(&fkv_lock);
+    size_t limit = fkv_top_k_limit_value;
+    pthread_mutex_unlock(&fkv_lock);
+    return limit;
+}
+
 int fkv_put(const uint8_t *key,
             size_t kn,
             const uint8_t *val,
             size_t vn,
-            fkv_entry_type_t type) {
-    if (!key || !val || kn == 0 || vn == 0) {
+            fkv_entry_type_t type,
+            double score) {
+    if (!key || !val || kn == 0 || vn == 0 || !isfinite(score)) {
         return -1;
     }
 
     pthread_mutex_lock(&fkv_lock);
-    int rc = fkv_put_locked(key, kn, val, vn, type);
+    int rc = fkv_put_locked(key, kn, val, vn, type, score);
     pthread_mutex_unlock(&fkv_lock);
     return rc;
-}
-
-static void collect_entries(const fkv_node_t *node,
-                            fkv_entry_t *entries,
-                            size_t *count,
-                            size_t limit) {
-    if (!node || *count >= limit) {
-        return;
-    }
-    if (node->value && *count < limit) {
-        entries[*count].key = node->key;
-        entries[*count].key_len = node->key_len;
-        entries[*count].value = node->value;
-        entries[*count].value_len = node->value_len;
-        entries[*count].type = node->type;
-        (*count)++;
-    }
-    for (size_t i = 0; i < 10 && *count < limit; ++i) {
-        collect_entries(node->children[i], entries, count, limit);
-    }
 }
 
 int fkv_get_prefix(const uint8_t *key, size_t kn, fkv_iter_t *it, size_t k) {
@@ -153,32 +317,52 @@ int fkv_get_prefix(const uint8_t *key, size_t kn, fkv_iter_t *it, size_t k) {
     }
 
     const fkv_node_t *node = fkv_root;
-    for (size_t i = 0; i < kn; ++i) {
-        uint8_t idx = key[i];
-        if (idx > 9) {
-            pthread_mutex_unlock(&fkv_lock);
-            return -1;
-        }
-        node = node->children[idx];
-        if (!node) {
-            pthread_mutex_unlock(&fkv_lock);
-            return 0;
+    if (key && kn > 0) {
+        for (size_t i = 0; i < kn; ++i) {
+            uint8_t idx = key[i];
+            if (idx > 9) {
+                pthread_mutex_unlock(&fkv_lock);
+                return -1;
+            }
+            node = node->children[idx];
+            if (!node) {
+                pthread_mutex_unlock(&fkv_lock);
+                return 0;
+            }
         }
     }
 
-    size_t limit = k ? k : 1;
-    fkv_entry_t *entries = calloc(limit, sizeof(fkv_entry_t));
+    size_t available = node->top_count;
+    if (available == 0) {
+        pthread_mutex_unlock(&fkv_lock);
+        return 0;
+    }
+
+    size_t limit = available;
+    if (k > 0 && k < limit) {
+        limit = k;
+    }
+
+    fkv_entry_t *entries = calloc(limit, sizeof(*entries));
     if (!entries) {
         pthread_mutex_unlock(&fkv_lock);
         return -1;
     }
 
-    size_t count = 0;
-    collect_entries(node, entries, &count, limit);
+    for (size_t i = 0; i < limit; ++i) {
+        const fkv_entry_payload_t *payload = node->top_entries[i];
+        entries[i].key = payload->key;
+        entries[i].key_len = payload->key_len;
+        entries[i].value = payload->value;
+        entries[i].value_len = payload->value_len;
+        entries[i].type = payload->type;
+        entries[i].score = payload->score;
+    }
+
     pthread_mutex_unlock(&fkv_lock);
 
     it->entries = entries;
-    it->count = count;
+    it->count = limit;
     return 0;
 }
 
@@ -195,7 +379,7 @@ static void count_entries(const fkv_node_t *node, size_t *count) {
     if (!node) {
         return;
     }
-    if (node->value) {
+    if (node->payload) {
         (*count)++;
     }
     for (size_t i = 0; i < 10; ++i) {
@@ -207,23 +391,27 @@ static int serialize_node(FILE *fp, const fkv_node_t *node) {
     if (!node) {
         return 0;
     }
-    if (node->value) {
-        uint64_t key_len = node->key_len;
-        uint64_t value_len = node->value_len;
-        uint8_t type = (uint8_t)node->type;
+    if (node->payload) {
+        uint64_t key_len = node->payload->key_len;
+        uint64_t value_len = node->payload->value_len;
+        uint8_t type = (uint8_t)node->payload->type;
+        double score = node->payload->score;
         if (fwrite(&key_len, sizeof(key_len), 1, fp) != 1) {
             return -1;
         }
-        if (key_len && fwrite(node->key, 1, key_len, fp) != key_len) {
+        if (key_len && fwrite(node->payload->key, 1, key_len, fp) != key_len) {
             return -1;
         }
         if (fwrite(&value_len, sizeof(value_len), 1, fp) != 1) {
             return -1;
         }
-        if (value_len && fwrite(node->value, 1, value_len, fp) != value_len) {
+        if (value_len && fwrite(node->payload->value, 1, value_len, fp) != value_len) {
             return -1;
         }
         if (fwrite(&type, sizeof(type), 1, fp) != 1) {
+            return -1;
+        }
+        if (fwrite(&score, sizeof(score), 1, fp) != 1) {
             return -1;
         }
     }
@@ -300,6 +488,7 @@ int fkv_load(const char *path) {
         uint64_t key_len = 0;
         uint64_t value_len = 0;
         uint8_t type = 0;
+        double score = 0.0;
 
         if (fread(&key_len, sizeof(key_len), 1, fp) != 1) {
             rc = -1;
@@ -338,15 +527,27 @@ int fkv_load(const char *path) {
             break;
         }
 
-        if (fkv_put(key_buf, (size_t)key_len, value_buf, (size_t)value_len, (fkv_entry_type_t)type) != 0) {
+        if (fread(&score, sizeof(score), 1, fp) != 1) {
             free(key_buf);
             free(value_buf);
             rc = -1;
             break;
         }
 
+        if (fkv_put(key_buf,
+                    (size_t)key_len,
+                    value_buf,
+                    (size_t)value_len,
+                    (fkv_entry_type_t)type,
+                    score) != 0) {
+            rc = -1;
+        }
+
         free(key_buf);
         free(value_buf);
+        if (rc != 0) {
+            break;
+        }
     }
 
     fclose(fp);

--- a/src/main.c
+++ b/src/main.c
@@ -278,7 +278,12 @@ static int run_chat(const kolibri_config_t *cfg) {
             int stored = 0;
             if (digits_from_number(exchange_id, key_digits, sizeof(key_digits), &key_len) == 0 &&
                 digits_from_number(value, val_digits, sizeof(val_digits), &val_len) == 0) {
-                if (fkv_put(key_digits, key_len, val_digits, val_len, FKV_ENTRY_TYPE_VALUE) == 0) {
+                if (fkv_put(key_digits,
+                            key_len,
+                            val_digits,
+                            val_len,
+                            FKV_ENTRY_TYPE_VALUE,
+                            (double)exchange_id) == 0) {
                     stored = 1;
                 }
             }
@@ -332,7 +337,7 @@ int main(int argc, char **argv) {
     }
 
     if (argc > 1 && strcmp(argv[1], "--chat") == 0) {
-        if (fkv_init() != 0) {
+        if (fkv_init(cfg.fkv.top_k) != 0) {
             log_error("failed to initialize F-KV");
             if (log_fp) {
                 fclose(log_fp);
@@ -347,7 +352,7 @@ int main(int argc, char **argv) {
         return rc;
     }
 
-    if (fkv_init() != 0) {
+    if (fkv_init(cfg.fkv.top_k) != 0) {
         log_error("failed to initialize F-KV");
         if (log_fp) {
             fclose(log_fp);

--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -309,7 +309,12 @@ int vm_run(const prog_t *p, const vm_limits_t *lim, vm_trace_t *trace, vm_result
                 status = VM_ERR_INVALID_OPCODE;
                 goto done;
             }
-            fkv_put(key_digits, key_len, value_digits, value_len, FKV_ENTRY_TYPE_VALUE);
+            fkv_put(key_digits,
+                    key_len,
+                    value_digits,
+                    value_len,
+                    FKV_ENTRY_TYPE_VALUE,
+                    (double)value_num);
             break;
         }
         case 0x0E: { // HASH10

--- a/tests/unit/test_config.c
+++ b/tests/unit/test_config.c
@@ -43,6 +43,9 @@ static void test_config_valid(void) {
         "    \"max_stack\": 256,\n"
         "    \"trace_depth\": 32\n"
         "  },\n"
+        "  \"fkv\": {\n"
+        "    \"top_k\": 12\n"
+        "  },\n"
         "  \"seed\": 777\n"
         "}\n";
 
@@ -55,6 +58,7 @@ static void test_config_valid(void) {
     assert(cfg.vm.max_steps == 4096);
     assert(cfg.vm.max_stack == 256);
     assert(cfg.vm.trace_depth == 32);
+    assert(cfg.fkv.top_k == 12);
     assert(cfg.seed == 777);
     remove_temp_file(path);
 }

--- a/tests/unit/test_fkv.c
+++ b/tests/unit/test_fkv.c
@@ -9,7 +9,10 @@
 #include <string.h>
 #include <unistd.h>
 
-static void insert_sample(const char *key_str, const char *val_str, fkv_entry_type_t type) {
+static void insert_sample(const char *key_str,
+                          const char *val_str,
+                          fkv_entry_type_t type,
+                          double score) {
     size_t klen = strlen(key_str);
     size_t vlen = strlen(val_str);
     uint8_t *kbuf = malloc(klen);
@@ -20,9 +23,17 @@ static void insert_sample(const char *key_str, const char *val_str, fkv_entry_ty
     for (size_t i = 0; i < vlen; ++i) {
         vbuf[i] = (uint8_t)(val_str[i] - '0');
     }
-    assert(fkv_put(kbuf, klen, vbuf, vlen, type) == 0);
+    assert(fkv_put(kbuf, klen, vbuf, vlen, type, score) == 0);
     free(kbuf);
     free(vbuf);
+}
+
+static void assert_key_equals(const fkv_entry_t *entry, const char *expected) {
+    size_t len = strlen(expected);
+    assert(entry->key_len == len);
+    for (size_t i = 0; i < len; ++i) {
+        assert(entry->key[i] == (uint8_t)(expected[i] - '0'));
+    }
 }
 
 static void create_temp_snapshot(char *buffer, size_t buffer_size, const char *tag) {
@@ -34,11 +45,11 @@ static void create_temp_snapshot(char *buffer, size_t buffer_size, const char *t
 }
 
 static void test_prefix(void) {
-    fkv_init();
-    insert_sample("123", "45", FKV_ENTRY_TYPE_VALUE);
-    insert_sample("124", "67", FKV_ENTRY_TYPE_VALUE);
-    insert_sample("129", "89", FKV_ENTRY_TYPE_VALUE);
-    insert_sample("880", "987654", FKV_ENTRY_TYPE_PROGRAM);
+    fkv_init(4);
+    insert_sample("123", "45", FKV_ENTRY_TYPE_VALUE, 0.5);
+    insert_sample("124", "67", FKV_ENTRY_TYPE_VALUE, 0.75);
+    insert_sample("129", "89", FKV_ENTRY_TYPE_VALUE, 0.25);
+    insert_sample("880", "987654", FKV_ENTRY_TYPE_PROGRAM, 0.9);
 
     uint8_t prefix[] = {1, 2};
     fkv_iter_t it = {0};
@@ -59,9 +70,9 @@ static void test_prefix(void) {
 }
 
 static void test_serialization_roundtrip(void) {
-    fkv_init();
-    insert_sample("123", "45", FKV_ENTRY_TYPE_VALUE);
-    insert_sample("555", "99", FKV_ENTRY_TYPE_VALUE);
+    fkv_init(3);
+    insert_sample("123", "45", FKV_ENTRY_TYPE_VALUE, 1.25);
+    insert_sample("555", "99", FKV_ENTRY_TYPE_VALUE, 2.5);
 
     char snapshot[128];
     create_temp_snapshot(snapshot, sizeof(snapshot), "fkv_snapshot_roundtrip");
@@ -77,12 +88,14 @@ static void test_serialization_roundtrip(void) {
     assert(it.count == 1);
     assert(it.entries[0].value_len == 2);
     assert(memcmp(it.entries[0].value, (uint8_t[]){4, 5}, 2) == 0);
+    assert(it.entries[0].score == 1.25);
     fkv_iter_free(&it);
 
     uint8_t key555[] = {5, 5, 5};
     assert(fkv_get_prefix(key555, sizeof(key555), &it, 1) == 0);
     assert(it.count == 1);
     assert(memcmp(it.entries[0].value, (uint8_t[]){9, 9}, 2) == 0);
+    assert(it.entries[0].score == 2.5);
     fkv_iter_free(&it);
 
     fkv_shutdown();
@@ -91,16 +104,16 @@ static void test_serialization_roundtrip(void) {
 }
 
 static void test_load_overwrites_existing(void) {
-    fkv_init();
-    insert_sample("123", "45", FKV_ENTRY_TYPE_VALUE);
+    fkv_init(2);
+    insert_sample("123", "45", FKV_ENTRY_TYPE_VALUE, 0.4);
 
     char snapshot[128];
     create_temp_snapshot(snapshot, sizeof(snapshot), "fkv_snapshot_overwrite");
     assert(fkv_save(snapshot) == 0);
     fkv_shutdown();
 
-    fkv_init();
-    insert_sample("999", "11", FKV_ENTRY_TYPE_VALUE);
+    fkv_init(2);
+    insert_sample("999", "11", FKV_ENTRY_TYPE_VALUE, 0.7);
     assert(fkv_load(snapshot) == 0);
 
     uint8_t key999[] = {9, 9, 9};
@@ -117,10 +130,44 @@ static void test_load_overwrites_existing(void) {
     unlink(snapshot);
 }
 
+static void test_topk_enforced(void) {
+    fkv_init(3);
+    insert_sample("120", "01", FKV_ENTRY_TYPE_VALUE, 0.4);
+    insert_sample("121", "02", FKV_ENTRY_TYPE_VALUE, 0.9);
+    insert_sample("122", "03", FKV_ENTRY_TYPE_VALUE, 0.7);
+    insert_sample("123", "04", FKV_ENTRY_TYPE_VALUE, 0.6);
+
+    uint8_t prefix[] = {1, 2};
+    fkv_iter_t it = {0};
+    assert(fkv_get_prefix(prefix, sizeof(prefix), &it, 0) == 0);
+    assert(it.count == 3);
+    assert_key_equals(&it.entries[0], "121");
+    assert(it.entries[0].score == 0.9);
+    assert_key_equals(&it.entries[1], "122");
+    assert(it.entries[1].score == 0.7);
+    assert_key_equals(&it.entries[2], "123");
+    assert(it.entries[2].score == 0.6);
+    fkv_iter_free(&it);
+
+    insert_sample("123", "14", FKV_ENTRY_TYPE_VALUE, 0.95);
+    assert(fkv_get_prefix(prefix, sizeof(prefix), &it, 0) == 0);
+    assert(it.count == 3);
+    assert_key_equals(&it.entries[0], "123");
+    assert(it.entries[0].score == 0.95);
+    assert_key_equals(&it.entries[1], "121");
+    assert(it.entries[1].score == 0.9);
+    assert_key_equals(&it.entries[2], "122");
+    assert(it.entries[2].score == 0.7);
+    fkv_iter_free(&it);
+
+    fkv_shutdown();
+}
+
 int main(void) {
     test_prefix();
     test_serialization_roundtrip();
     test_load_overwrites_existing();
+    test_topk_enforced();
     printf("fkv tests passed\n");
     return 0;
 }


### PR DESCRIPTION
## Summary
- redesign F-KV trie nodes to hold scored payloads and maintain ordered top-K lists with updated serialization
- extend configuration with an fkv.top_k limit and update callers to provide scores when writing
- expand unit tests and defaults to validate ordered top-K retrieval and config parsing

## Testing
- make test-fkv *(fails: existing Makefile reports "missing separator")*
- build/tests/unit/test_fkv
- build/tests/unit/test_config
- build/tests/unit/test_vm

------
https://chatgpt.com/codex/tasks/task_e_68d35d7aa6ac8323b3ea68d5bbb2a703