### PR TITLE
Add Δ-VM and F-KV benchmark harness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,11 +21,9 @@ SRC := \
   src/http/http_server.c \
   src/http/http_routes.c \
   src/blockchain.c \
-
   src/formula_runtime.c \
   src/synthesis/search.c \
-  src/synthesis/formula_vm_eval.c
-
+  src/synthesis/formula_vm_eval.c \
   src/formula_stub.c \
   src/protocol/swarm.c
 

--- a/README.md
+++ b/README.md
@@ -46,13 +46,14 @@ Other CLI commands:
 
 ```
 ./kolibri.sh stop   # stop running node
-./kolibri.sh bench  # run Δ-VM & F-KV microbenchmarks (mean/p95 latency, VM steps)
+./kolibri.sh bench  # run Δ-VM & F-KV microbenchmarks (mean/p95/stddev latency, VM steps)
 ./kolibri.sh clean  # remove build artifacts, logs, and data
 ```
 
 The suite runs three deterministic Δ-VM programs plus 1000 `fkv_put`/`fkv_get` prefix lookups. Each line reports mean, p95,
-minimum, and maximum latency in microseconds; Δ-VM entries also print average/min/max step counts and the HALT ratio to confirm
-execution limits. A copy of the results is appended to `logs/bench.log` for later comparison.
+standard deviation, minimum, and maximum latency in microseconds alongside the achieved throughput (ops/s); Δ-VM entries also
+print average/min/max step counts and the HALT ratio to confirm execution limits while F-KV validates stored values. Results
+are appended to `logs/bench.log` and exported as structured JSON in `logs/bench.json` for programmatic comparison.
 
 ### Console chat mode
 

--- a/README.md
+++ b/README.md
@@ -46,9 +46,13 @@ Other CLI commands:
 
 ```
 ./kolibri.sh stop   # stop running node
-./kolibri.sh bench  # run built-in benchmarks (placeholder)
+./kolibri.sh bench  # run Δ-VM & F-KV microbenchmarks (mean/p95 latency, VM steps)
 ./kolibri.sh clean  # remove build artifacts, logs, and data
 ```
+
+The suite runs three deterministic Δ-VM programs plus 1000 `fkv_put`/`fkv_get` prefix lookups. Each line reports mean, p95,
+minimum, and maximum latency in microseconds; Δ-VM entries also print average/min/max step counts and the HALT ratio to confirm
+execution limits. A copy of the results is appended to `logs/bench.log` for later comparison.
 
 ### Console chat mode
 

--- a/kolibri.sh
+++ b/kolibri.sh
@@ -56,7 +56,7 @@ case "${1:-}" in
   bench)
     echo "[kolibri] running Δ-VM and F-KV microbenchmarks" >&2
     make -C "$ROOT_DIR" bench
-    echo "[kolibri] benchmark metrics saved to $LOG_DIR/bench.log" >&2
+    echo "[kolibri] benchmark metrics saved to $LOG_DIR/bench.log and $LOG_DIR/bench.json" >&2
     ;;
   clean)
     stop_node || true

--- a/kolibri.sh
+++ b/kolibri.sh
@@ -54,7 +54,9 @@ case "${1:-}" in
     stop_node
     ;;
   bench)
+    echo "[kolibri] running Δ-VM and F-KV microbenchmarks" >&2
     make -C "$ROOT_DIR" bench
+    echo "[kolibri] benchmark metrics saved to $LOG_DIR/bench.log" >&2
     ;;
   clean)
     stop_node || true


### PR DESCRIPTION
## Summary
- implement a microbenchmark suite in `kolibri_node --bench` that times fixed Δ-VM programs and batched F-KV put/get operations while computing mean/p95/min/max latencies and VM step stats, and persist the report to `logs/bench.log`
- surface the benchmark workflow through `kolibri.sh bench` and document the reported metrics in the README
- normalize the `SRC` list in the Makefile so the bench target builds cleanly

## Testing
- `make bench`


------
https://chatgpt.com/codex/tasks/task_e_68d35faba6748323900c718ff043b73c