### PR TITLE
Add F-KV persistence and replication

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,33 +11,36 @@ BUILD_DIR := build/obj
 BIN_DIR := bin
 TARGET := $(BIN_DIR)/kolibri_node
 
+LDFLAGS += -lz
+
 SRC := \
-  src/main.c \
-  src/util/log.c \
-  src/util/config.c \
-  src/vm/vm.c \
-  src/fkv/fkv.c \
-  src/kolibri_ai.c \
-  src/http/http_server.c \
-  src/http/http_routes.c \
-  src/blockchain.c \
+	 src/main.c \
+	 src/util/log.c \
+	 src/util/config.c \
+	 src/vm/vm.c \
+	 src/fkv/fkv.c \
+	 src/fkv/persistence.c \
+	 src/fkv/replication.c \
+	 src/kolibri_ai.c \
+	 src/http/http_server.c \
+	 src/http/http_routes.c \
+	 src/blockchain.c \
+	 src/formula_runtime.c \
+	 src/synthesis/search.c \
+	 src/synthesis/formula_vm_eval.c \
+	 src/formula_stub.c \
+	 src/protocol/swarm.c
 
-  src/formula_runtime.c \
-  src/synthesis/search.c \
-  src/synthesis/formula_vm_eval.c
 
-  src/formula_stub.c \
-  src/protocol/swarm.c
-
-
-TEST_VM_SRC := tests/unit/test_vm.c src/vm/vm.c src/util/log.c src/util/config.c src/fkv/fkv.c
-TEST_FKV_SRC := tests/unit/test_fkv.c src/fkv/fkv.c src/util/log.c src/util/config.c
+TEST_VM_SRC := tests/unit/test_vm.c src/vm/vm.c src/util/log.c src/util/config.c src/fkv/fkv.c src/fkv/persistence.c src/fkv/replication.c src/protocol/swarm.c
+TEST_FKV_SRC := tests/unit/test_fkv.c src/fkv/fkv.c src/fkv/persistence.c src/fkv/replication.c src/util/log.c src/util/config.c src/protocol/swarm.c
 TEST_CONFIG_SRC := tests/unit/test_config.c src/util/config.c src/util/log.c
 
-TEST_KOLIBRI_ITER_SRC := tests/test_kolibri_ai_iterations.c src/kolibri_ai.c src/formula_runtime.c src/synthesis/search.c src/synthesis/formula_vm_eval.c src/vm/vm.c src/fkv/fkv.c
+TEST_KOLIBRI_ITER_SRC := tests/test_kolibri_ai_iterations.c src/kolibri_ai.c src/formula_runtime.c src/synthesis/search.c src/synthesis/formula_vm_eval.c src/vm/vm.c src/fkv/fkv.c src/fkv/persistence.c src/fkv/replication.c src/protocol/swarm.c
 
-TEST_KOLIBRI_ITER_SRC := tests/test_kolibri_ai_iterations.c src/kolibri_ai.c src/formula_runtime.c
 TEST_SWARM_PROTOCOL_SRC := tests/unit/test_swarm_protocol.c src/protocol/swarm.c
+
+TEST_FKV_CLUSTER_SRC := tests/integration/test_fkv_cluster.c src/fkv/fkv.c src/fkv/persistence.c src/fkv/replication.c src/util/log.c src/util/config.c src/protocol/swarm.c
 
 
 
@@ -70,7 +73,7 @@ clean:
 
 
 
-test: build test-vm test-fkv test-config test-kolibri-ai test-swarm-protocol
+test: build test-vm test-fkv test-config test-kolibri-ai test-swarm-protocol test-fkv-cluster
 
 
 $(BUILD_DIR)/tests/unit/test_vm: $(TEST_VM_SRC)
@@ -86,7 +89,6 @@ test-vm: $(BUILD_DIR)/tests/unit/test_vm
 
 test-fkv: $(BUILD_DIR)/tests/unit/test_fkv
 	$<
-
 
 $(BUILD_DIR)/tests/unit/test_config: $(TEST_CONFIG_SRC)
 	@mkdir -p $(BUILD_DIR)/tests/unit
@@ -107,6 +109,13 @@ $(BUILD_DIR)/tests/unit/test_swarm_protocol: $(TEST_SWARM_PROTOCOL_SRC)
 	$(CC) $(CFLAGS) $(TEST_SWARM_PROTOCOL_SRC) -o $@ $(filter-out -ljson-c -luuid,$(LDFLAGS))
 
 test-swarm-protocol: $(BUILD_DIR)/tests/unit/test_swarm_protocol
+	$<
+
+$(BUILD_DIR)/tests/integration/test_fkv_cluster: $(TEST_FKV_CLUSTER_SRC)
+	@mkdir -p $(BUILD_DIR)/tests/integration
+	$(CC) $(CFLAGS) $(TEST_FKV_CLUSTER_SRC) -o $@ $(LDFLAGS)
+
+test-fkv-cluster: $(BUILD_DIR)/tests/integration/test_fkv_cluster
 	$<
 
 bench: build

--- a/include/fkv/persistence.h
+++ b/include/fkv/persistence.h
@@ -1,0 +1,47 @@
+#ifndef KOLIBRI_FKV_PERSISTENCE_H
+#define KOLIBRI_FKV_PERSISTENCE_H
+
+#include "fkv/fkv.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    const char *wal_path;
+    const char *snapshot_dir;
+    size_t snapshot_interval;
+} fkv_persistence_config_t;
+
+typedef int (*fkv_persistence_apply_fn)(const uint8_t *key,
+                                        size_t key_len,
+                                        const uint8_t *value,
+                                        size_t value_len,
+                                        fkv_entry_type_t type,
+                                        void *userdata);
+
+int fkv_persistence_configure(const fkv_persistence_config_t *config);
+void fkv_persistence_disable(void);
+bool fkv_persistence_enabled(void);
+
+int fkv_persistence_start(fkv_persistence_apply_fn apply, void *userdata);
+int fkv_persistence_record_put(const uint8_t *key,
+                               size_t key_len,
+                               const uint8_t *value,
+                               size_t value_len,
+                               fkv_entry_type_t type);
+int fkv_persistence_force_checkpoint(void);
+void fkv_persistence_shutdown(void);
+
+const char *fkv_persistence_wal_path(void);
+const char *fkv_persistence_base_snapshot_path(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/fkv/replication.h
+++ b/include/fkv/replication.h
@@ -1,0 +1,23 @@
+#ifndef KOLIBRI_FKV_REPLICATION_H
+#define KOLIBRI_FKV_REPLICATION_H
+
+#include "protocol/swarm.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int fkv_replication_build_delta(const uint8_t *prefix_digits,
+                                size_t prefix_len,
+                                SwarmFrame *frame);
+int fkv_replication_apply_delta(const SwarmFrame *frame);
+void fkv_replication_free_delta(SwarmFrame *frame);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/protocol/swarm.h
+++ b/include/protocol/swarm.h
@@ -51,8 +51,11 @@ typedef struct {
 typedef struct {
     char prefix[SWARM_PREFIX_DIGITS + 1];
     uint16_t entry_count;
+    uint32_t raw_size;
     uint32_t compressed_size;
     uint16_t checksum;
+    uint8_t *data;
+    size_t data_len;
 } SwarmFkvDeltaPayload;
 
 typedef struct {
@@ -110,5 +113,9 @@ void swarm_peer_report_violation(SwarmPeerState *peer, SwarmFrameType type);
 
 int swarm_frame_serialize(const SwarmFrame *frame, char *out, size_t out_size, size_t *written);
 int swarm_frame_parse(const char *data, size_t len, SwarmFrame *frame);
+
+uint16_t swarm_crc16(const uint8_t *data, size_t len);
+int swarm_fkv_prefix_encode(const uint8_t *digits, size_t len, char out[SWARM_PREFIX_DIGITS + 1]);
+int swarm_fkv_prefix_decode(const char prefix[SWARM_PREFIX_DIGITS + 1], uint8_t *digits_out, size_t *len_out);
 
 #endif // KOLIBRI_PROTOCOL_SWARM_H

--- a/src/fkv/persistence.c
+++ b/src/fkv/persistence.c
@@ -1,0 +1,873 @@
+#include "fkv/persistence.h"
+
+#include <dirent.h>
+#include <errno.h>
+#include <limits.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <zlib.h>
+
+#define WAL_MAGIC 0x464B574C /* FKWL */
+#define WAL_VERSION 1
+#define WAL_HEADER_SIZE (sizeof(uint32_t) + sizeof(uint16_t))
+#define WAL_OP_PUT 1
+
+#define DELTA_MAGIC 0x464B5644 /* FKVD */
+#define DELTA_VERSION 1
+
+#define BASE_SNAPSHOT_NAME "base.fkz"
+#define DELTA_PREFIX "delta_"
+#define DELTA_SUFFIX ".fkz"
+
+typedef struct {
+    bool enabled;
+    char wal_path[PATH_MAX];
+    char snapshot_dir[PATH_MAX];
+    char base_snapshot_path[PATH_MAX];
+    size_t snapshot_interval;
+    size_t wal_ops_since_checkpoint;
+    uint64_t next_delta_seq;
+    FILE *wal_fp;
+} fkv_persistence_state_t;
+
+typedef struct {
+    uint64_t index;
+    char path[PATH_MAX];
+} fkv_delta_file_t;
+
+static fkv_persistence_state_t g_state = {0};
+
+static uint32_t compute_crc32(const uint8_t *data, size_t len) {
+    uLong crc = crc32(0L, Z_NULL, 0);
+    while (len > 0) {
+        uInt chunk = len > UINT_MAX ? UINT_MAX : (uInt)len;
+        crc = crc32(crc, data, chunk);
+        data += chunk;
+        len -= chunk;
+    }
+    return (uint32_t)crc;
+}
+
+static int ensure_dir_recursive(const char *path) {
+    if (!path || *path == '\0') {
+        errno = EINVAL;
+        return -1;
+    }
+    char buffer[PATH_MAX];
+    size_t len = strlen(path);
+    if (len == 0 || len >= sizeof(buffer)) {
+        errno = ENAMETOOLONG;
+        return -1;
+    }
+    memcpy(buffer, path, len);
+    buffer[len] = '\0';
+    if (buffer[len - 1] == '/') {
+        buffer[len - 1] = '\0';
+    }
+    for (char *p = buffer + 1; *p; ++p) {
+        if (*p == '/') {
+            *p = '\0';
+            if (buffer[0] != '\0') {
+                if (mkdir(buffer, 0755) != 0 && errno != EEXIST) {
+                    return -1;
+                }
+            }
+            *p = '/';
+        }
+    }
+    if (buffer[0] != '\0') {
+        if (mkdir(buffer, 0755) != 0 && errno != EEXIST) {
+            return -1;
+        }
+    }
+    return 0;
+}
+
+static int ensure_parent_dir(const char *path) {
+    if (!path) {
+        errno = EINVAL;
+        return -1;
+    }
+    char buffer[PATH_MAX];
+    size_t len = strlen(path);
+    if (len == 0 || len >= sizeof(buffer)) {
+        errno = ENAMETOOLONG;
+        return -1;
+    }
+    memcpy(buffer, path, len);
+    buffer[len] = '\0';
+    char *slash = strrchr(buffer, '/');
+    if (!slash || slash == buffer) {
+        return 0;
+    }
+    *slash = '\0';
+    if (*buffer == '\0') {
+        return 0;
+    }
+    return ensure_dir_recursive(buffer);
+}
+
+static int wal_write_header(FILE *fp) {
+    uint32_t magic = WAL_MAGIC;
+    uint16_t version = WAL_VERSION;
+    if (fwrite(&magic, sizeof(magic), 1, fp) != 1) {
+        return -1;
+    }
+    if (fwrite(&version, sizeof(version), 1, fp) != 1) {
+        return -1;
+    }
+    return fflush(fp);
+}
+
+static int wal_read_header(FILE *fp) {
+    uint32_t magic = 0;
+    uint16_t version = 0;
+    if (fread(&magic, sizeof(magic), 1, fp) != 1) {
+        return -1;
+    }
+    if (fread(&version, sizeof(version), 1, fp) != 1) {
+        return -1;
+    }
+    if (magic != WAL_MAGIC || version != WAL_VERSION) {
+        errno = EINVAL;
+        return -1;
+    }
+    return 0;
+}
+
+static int open_wal(void) {
+    if (!g_state.enabled) {
+        return 0;
+    }
+    FILE *fp = fopen(g_state.wal_path, "r+b");
+    if (!fp) {
+        if (errno != ENOENT) {
+            return -1;
+        }
+        fp = fopen(g_state.wal_path, "w+b");
+        if (!fp) {
+            return -1;
+        }
+        if (wal_write_header(fp) != 0) {
+            fclose(fp);
+            return -1;
+        }
+    } else {
+        if (fseek(fp, 0, SEEK_END) != 0) {
+            fclose(fp);
+            return -1;
+        }
+        long size = ftell(fp);
+        if (size < (long)WAL_HEADER_SIZE) {
+            if (fseek(fp, 0, SEEK_SET) != 0) {
+                fclose(fp);
+                return -1;
+            }
+            if (wal_write_header(fp) != 0) {
+                fclose(fp);
+                return -1;
+            }
+        }
+    }
+    if (fseek(fp, 0, SEEK_SET) != 0) {
+        fclose(fp);
+        return -1;
+    }
+    if (wal_read_header(fp) != 0) {
+        fclose(fp);
+        return -1;
+    }
+    g_state.wal_fp = fp;
+    return 0;
+}
+
+static int wal_read_payload(uint8_t **buffer, size_t *len) {
+    if (!g_state.wal_fp || !buffer || !len) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (fflush(g_state.wal_fp) != 0) {
+        return -1;
+    }
+    if (fseek(g_state.wal_fp, 0, SEEK_SET) != 0) {
+        return -1;
+    }
+    if (wal_read_header(g_state.wal_fp) != 0) {
+        return -1;
+    }
+    if (fseek(g_state.wal_fp, 0, SEEK_END) != 0) {
+        return -1;
+    }
+    long end = ftell(g_state.wal_fp);
+    if (end < (long)WAL_HEADER_SIZE) {
+        errno = EINVAL;
+        return -1;
+    }
+    size_t payload_size = (size_t)((unsigned long)end - WAL_HEADER_SIZE);
+    if (payload_size == 0) {
+        *buffer = NULL;
+        *len = 0;
+        return fseek(g_state.wal_fp, 0, SEEK_END);
+    }
+    if (fseek(g_state.wal_fp, WAL_HEADER_SIZE, SEEK_SET) != 0) {
+        return -1;
+    }
+    uint8_t *buf = malloc(payload_size);
+    if (!buf) {
+        return -1;
+    }
+    if (fread(buf, 1, payload_size, g_state.wal_fp) != payload_size) {
+        free(buf);
+        return -1;
+    }
+    if (fseek(g_state.wal_fp, 0, SEEK_END) != 0) {
+        free(buf);
+        return -1;
+    }
+    *buffer = buf;
+    *len = payload_size;
+    return 0;
+}
+
+static int iterate_log_buffer(const uint8_t *buffer,
+                              size_t len,
+                              fkv_persistence_apply_fn apply,
+                              void *userdata,
+                              size_t *count_out) {
+    if (!buffer && len != 0) {
+        errno = EINVAL;
+        return -1;
+    }
+    size_t offset = 0;
+    size_t count = 0;
+    while (offset < len) {
+        if (len - offset < 1 + 1 + sizeof(uint64_t) + sizeof(uint64_t)) {
+            errno = EINVAL;
+            return -1;
+        }
+        uint8_t op = buffer[offset++];
+        if (op != WAL_OP_PUT) {
+            errno = EINVAL;
+            return -1;
+        }
+        uint8_t type = buffer[offset++];
+        uint64_t key_len = 0;
+        memcpy(&key_len, buffer + offset, sizeof(uint64_t));
+        offset += sizeof(uint64_t);
+        if (key_len > len - offset) {
+            errno = EINVAL;
+            return -1;
+        }
+        const uint8_t *key_ptr = key_len ? buffer + offset : NULL;
+        offset += (size_t)key_len;
+        if (len - offset < sizeof(uint64_t)) {
+            errno = EINVAL;
+            return -1;
+        }
+        uint64_t value_len = 0;
+        memcpy(&value_len, buffer + offset, sizeof(uint64_t));
+        offset += sizeof(uint64_t);
+        if (value_len > len - offset) {
+            errno = EINVAL;
+            return -1;
+        }
+        const uint8_t *value_ptr = value_len ? buffer + offset : NULL;
+        offset += (size_t)value_len;
+        if (apply) {
+            if (apply(key_ptr,
+                      (size_t)key_len,
+                      value_ptr,
+                      (size_t)value_len,
+                      (fkv_entry_type_t)type,
+                      userdata) != 0) {
+                return -1;
+            }
+        }
+        ++count;
+    }
+    if (count_out) {
+        *count_out = count;
+    }
+    return 0;
+}
+
+static int delta_file_cmp(const void *a, const void *b) {
+    const fkv_delta_file_t *da = (const fkv_delta_file_t *)a;
+    const fkv_delta_file_t *db = (const fkv_delta_file_t *)b;
+    if (da->index < db->index) {
+        return -1;
+    }
+    if (da->index > db->index) {
+        return 1;
+    }
+    return strcmp(da->path, db->path);
+}
+
+static int collect_delta_files(fkv_delta_file_t **files_out, size_t *count_out) {
+    if (!files_out || !count_out) {
+        errno = EINVAL;
+        return -1;
+    }
+    *files_out = NULL;
+    *count_out = 0;
+    DIR *dir = opendir(g_state.snapshot_dir);
+    if (!dir) {
+        if (errno == ENOENT) {
+            g_state.next_delta_seq = 0;
+            return 0;
+        }
+        return -1;
+    }
+    size_t capacity = 8;
+    size_t count = 0;
+    fkv_delta_file_t *files = malloc(capacity * sizeof(*files));
+    if (!files) {
+        closedir(dir);
+        return -1;
+    }
+    struct dirent *entry;
+    size_t prefix_len = strlen(DELTA_PREFIX);
+    size_t suffix_len = strlen(DELTA_SUFFIX);
+    while ((entry = readdir(dir)) != NULL) {
+        const char *name = entry->d_name;
+        size_t name_len = strlen(name);
+        if (name_len <= prefix_len + suffix_len) {
+            continue;
+        }
+        if (strncmp(name, DELTA_PREFIX, prefix_len) != 0) {
+            continue;
+        }
+        if (strcmp(name + name_len - suffix_len, DELTA_SUFFIX) != 0) {
+            continue;
+        }
+        size_t digits_len = name_len - prefix_len - suffix_len;
+        if (digits_len == 0 || digits_len >= 32) {
+            continue;
+        }
+        char number_buf[32];
+        memcpy(number_buf, name + prefix_len, digits_len);
+        number_buf[digits_len] = '\0';
+        char *endptr = NULL;
+        errno = 0;
+        unsigned long long idx = strtoull(number_buf, &endptr, 10);
+        if (errno != 0 || !endptr || *endptr != '\0') {
+            continue;
+        }
+        if (count == capacity) {
+            size_t new_capacity = capacity * 2;
+            fkv_delta_file_t *tmp = realloc(files, new_capacity * sizeof(*files));
+            if (!tmp) {
+                free(files);
+                closedir(dir);
+                return -1;
+            }
+            files = tmp;
+            capacity = new_capacity;
+        }
+        files[count].index = (uint64_t)idx;
+        if (snprintf(files[count].path,
+                     sizeof(files[count].path),
+                     "%s/%s",
+                     g_state.snapshot_dir,
+                     name) >= (int)sizeof(files[count].path)) {
+            free(files);
+            closedir(dir);
+            errno = ENAMETOOLONG;
+            return -1;
+        }
+        ++count;
+    }
+    closedir(dir);
+    if (count > 1) {
+        qsort(files, count, sizeof(*files), delta_file_cmp);
+    }
+    if (count > 0) {
+        g_state.next_delta_seq = files[count - 1].index + 1;
+    } else {
+        g_state.next_delta_seq = 0;
+    }
+    *files_out = files;
+    *count_out = count;
+    return 0;
+}
+
+static int apply_log_buffer(const uint8_t *buffer,
+                            size_t len,
+                            fkv_persistence_apply_fn apply,
+                            void *userdata,
+                            size_t *applied) {
+    return iterate_log_buffer(buffer, len, apply, userdata, applied);
+}
+
+static int apply_delta_file(const char *path, fkv_persistence_apply_fn apply, void *userdata) {
+    FILE *fp = fopen(path, "rb");
+    if (!fp) {
+        return -1;
+    }
+    int rc = -1;
+    uint32_t magic = 0;
+    uint16_t version = 0;
+    uint64_t raw_size = 0;
+    uint64_t record_count = 0;
+    uint32_t crc32_expected = 0;
+    uint64_t compressed_size = 0;
+    if (fread(&magic, sizeof(magic), 1, fp) != 1 || magic != DELTA_MAGIC) {
+        goto out;
+    }
+    if (fread(&version, sizeof(version), 1, fp) != 1 || version != DELTA_VERSION) {
+        goto out;
+    }
+    if (fread(&raw_size, sizeof(raw_size), 1, fp) != 1) {
+        goto out;
+    }
+    if (fread(&record_count, sizeof(record_count), 1, fp) != 1) {
+        goto out;
+    }
+    if (fread(&crc32_expected, sizeof(crc32_expected), 1, fp) != 1) {
+        goto out;
+    }
+    if (fread(&compressed_size, sizeof(compressed_size), 1, fp) != 1) {
+        goto out;
+    }
+    uint8_t *compressed = NULL;
+    if (compressed_size > 0) {
+        compressed = malloc((size_t)compressed_size);
+        if (!compressed) {
+            goto out;
+        }
+        if (fread(compressed, 1, (size_t)compressed_size, fp) != (size_t)compressed_size) {
+            free(compressed);
+            goto out;
+        }
+    }
+    fclose(fp);
+    fp = NULL;
+    uint8_t *raw = NULL;
+    if (raw_size > 0) {
+        raw = malloc((size_t)raw_size);
+        if (!raw) {
+            free(compressed);
+            return -1;
+        }
+        uLongf dest_len = (uLongf)raw_size;
+        if (uncompress(raw, &dest_len, compressed, (uLongf)compressed_size) != Z_OK || dest_len != raw_size) {
+            free(raw);
+            free(compressed);
+            return -1;
+        }
+    }
+    free(compressed);
+    uint32_t crc32_actual = compute_crc32(raw, (size_t)raw_size);
+    if (crc32_actual != crc32_expected) {
+        free(raw);
+        errno = EINVAL;
+        return -1;
+    }
+    size_t applied = 0;
+    if (raw_size > 0) {
+        if (apply_log_buffer(raw, (size_t)raw_size, apply, userdata, &applied) != 0) {
+            free(raw);
+            return -1;
+        }
+    }
+    free(raw);
+    if (applied != record_count) {
+        if (!(applied == 0 && record_count == 0)) {
+            errno = EINVAL;
+            return -1;
+        }
+    }
+    rc = 0;
+out:
+    if (fp) {
+        fclose(fp);
+    }
+    return rc;
+}
+
+static int apply_delta_files(const fkv_delta_file_t *files,
+                             size_t count,
+                             fkv_persistence_apply_fn apply,
+                             void *userdata) {
+    for (size_t i = 0; i < count; ++i) {
+        if (apply_delta_file(files[i].path, apply, userdata) != 0) {
+            return -1;
+        }
+    }
+    return 0;
+}
+
+static int load_base_snapshot(fkv_persistence_apply_fn apply, void *userdata) {
+    if (g_state.base_snapshot_path[0] == '\0') {
+        return 0;
+    }
+    gzFile fp = gzopen(g_state.base_snapshot_path, "rb");
+    if (!fp) {
+        if (errno == ENOENT) {
+            return 0;
+        }
+        return -1;
+    }
+    uint64_t entry_count = 0;
+    if (gzread(fp, &entry_count, sizeof(entry_count)) != (int)sizeof(entry_count)) {
+        gzclose(fp);
+        return -1;
+    }
+    for (uint64_t i = 0; i < entry_count; ++i) {
+        uint64_t key_len = 0;
+        uint64_t value_len = 0;
+        if (gzread(fp, &key_len, sizeof(key_len)) != (int)sizeof(key_len)) {
+            gzclose(fp);
+            return -1;
+        }
+        uint8_t *key = NULL;
+        if (key_len > 0) {
+            key = malloc((size_t)key_len);
+            if (!key) {
+                gzclose(fp);
+                return -1;
+            }
+            if (gzread(fp, key, (unsigned int)key_len) != (int)key_len) {
+                free(key);
+                gzclose(fp);
+                return -1;
+            }
+        }
+        if (gzread(fp, &value_len, sizeof(value_len)) != (int)sizeof(value_len)) {
+            free(key);
+            gzclose(fp);
+            return -1;
+        }
+        uint8_t *value = NULL;
+        if (value_len > 0) {
+            value = malloc((size_t)value_len);
+            if (!value) {
+                free(key);
+                gzclose(fp);
+                return -1;
+            }
+            if (gzread(fp, value, (unsigned int)value_len) != (int)value_len) {
+                free(key);
+                free(value);
+                gzclose(fp);
+                return -1;
+            }
+        }
+        unsigned char type_byte = 0;
+        if (gzread(fp, &type_byte, sizeof(type_byte)) != (int)sizeof(type_byte)) {
+            free(key);
+            free(value);
+            gzclose(fp);
+            return -1;
+        }
+        if (apply(key,
+                  (size_t)key_len,
+                  value,
+                  (size_t)value_len,
+                  (fkv_entry_type_t)type_byte,
+                  userdata) != 0) {
+            free(key);
+            free(value);
+            gzclose(fp);
+            return -1;
+        }
+        free(key);
+        free(value);
+    }
+    gzclose(fp);
+    return 0;
+}
+
+static int reset_wal(void) {
+    if (g_state.wal_fp) {
+        fclose(g_state.wal_fp);
+        g_state.wal_fp = NULL;
+    }
+    FILE *fp = fopen(g_state.wal_path, "w+b");
+    if (!fp) {
+        return -1;
+    }
+    if (wal_write_header(fp) != 0) {
+        fclose(fp);
+        return -1;
+    }
+    fclose(fp);
+    return open_wal();
+}
+
+int fkv_persistence_force_checkpoint(void) {
+    if (!g_state.enabled || !g_state.wal_fp) {
+        return 0;
+    }
+    uint8_t *payload = NULL;
+    size_t payload_len = 0;
+    if (wal_read_payload(&payload, &payload_len) != 0) {
+        free(payload);
+        return -1;
+    }
+    if (payload_len == 0) {
+        free(payload);
+        g_state.wal_ops_since_checkpoint = 0;
+        return 0;
+    }
+    size_t record_count = 0;
+    if (iterate_log_buffer(payload, payload_len, NULL, NULL, &record_count) != 0) {
+        free(payload);
+        return -1;
+    }
+    if (record_count == 0) {
+        free(payload);
+        g_state.wal_ops_since_checkpoint = 0;
+        return 0;
+    }
+    uint32_t crc = compute_crc32(payload, payload_len);
+    uLongf compressed_capacity = compressBound(payload_len);
+    uint8_t *compressed = malloc(compressed_capacity);
+    if (!compressed) {
+        free(payload);
+        return -1;
+    }
+    uLongf compressed_len = compressed_capacity;
+    if (compress2(compressed, &compressed_len, payload, payload_len, Z_BEST_SPEED) != Z_OK) {
+        free(payload);
+        free(compressed);
+        return -1;
+    }
+    if (ensure_dir_recursive(g_state.snapshot_dir) != 0) {
+        free(payload);
+        free(compressed);
+        return -1;
+    }
+    char delta_path[PATH_MAX];
+    if (snprintf(delta_path,
+                 sizeof(delta_path),
+                 "%s/%s%012llu%s",
+                 g_state.snapshot_dir,
+                 DELTA_PREFIX,
+                 (unsigned long long)g_state.next_delta_seq,
+                 DELTA_SUFFIX) >= (int)sizeof(delta_path)) {
+        free(payload);
+        free(compressed);
+        errno = ENAMETOOLONG;
+        return -1;
+    }
+    FILE *dfp = fopen(delta_path, "wb");
+    if (!dfp) {
+        free(payload);
+        free(compressed);
+        return -1;
+    }
+    uint32_t magic = DELTA_MAGIC;
+    uint16_t version = DELTA_VERSION;
+    uint64_t raw_size = payload_len;
+    uint64_t record_count64 = record_count;
+    uint64_t compressed_size = (uint64_t)compressed_len;
+    int rc = 0;
+    if (fwrite(&magic, sizeof(magic), 1, dfp) != 1 ||
+        fwrite(&version, sizeof(version), 1, dfp) != 1 ||
+        fwrite(&raw_size, sizeof(raw_size), 1, dfp) != 1 ||
+        fwrite(&record_count64, sizeof(record_count64), 1, dfp) != 1 ||
+        fwrite(&crc, sizeof(crc), 1, dfp) != 1 ||
+        fwrite(&compressed_size, sizeof(compressed_size), 1, dfp) != 1) {
+        rc = -1;
+    }
+    if (rc == 0 && compressed_len > 0) {
+        if (fwrite(compressed, 1, (size_t)compressed_len, dfp) != (size_t)compressed_len) {
+            rc = -1;
+        }
+    }
+    if (fflush(dfp) != 0) {
+        rc = -1;
+    }
+    if (fclose(dfp) != 0) {
+        rc = -1;
+    }
+    free(compressed);
+    if (rc != 0) {
+        free(payload);
+        unlink(delta_path);
+        return -1;
+    }
+    g_state.next_delta_seq += 1;
+    free(payload);
+    if (reset_wal() != 0) {
+        return -1;
+    }
+    g_state.wal_ops_since_checkpoint = 0;
+    return 0;
+}
+static int apply_wal(fkv_persistence_apply_fn apply, void *userdata) {
+    uint8_t *payload = NULL;
+    size_t payload_len = 0;
+    if (wal_read_payload(&payload, &payload_len) != 0) {
+        free(payload);
+        return -1;
+    }
+    size_t applied = 0;
+    int rc = 0;
+    if (payload_len > 0) {
+        rc = apply_log_buffer(payload, payload_len, apply, userdata, &applied);
+    }
+    free(payload);
+    if (rc == 0) {
+        g_state.wal_ops_since_checkpoint = applied;
+    }
+    return rc;
+}
+
+int fkv_persistence_configure(const fkv_persistence_config_t *config) {
+    if (!config || !config->wal_path || !config->snapshot_dir) {
+        errno = EINVAL;
+        return -1;
+    }
+    fkv_persistence_disable();
+    g_state.enabled = true;
+    size_t wal_len = strlen(config->wal_path);
+    if (wal_len == 0 || wal_len >= sizeof(g_state.wal_path)) {
+        fkv_persistence_disable();
+        errno = ENAMETOOLONG;
+        return -1;
+    }
+    memcpy(g_state.wal_path, config->wal_path, wal_len);
+    g_state.wal_path[wal_len] = '\0';
+    size_t dir_len = strlen(config->snapshot_dir);
+    if (dir_len == 0 || dir_len >= sizeof(g_state.snapshot_dir)) {
+        fkv_persistence_disable();
+        errno = ENAMETOOLONG;
+        return -1;
+    }
+    memcpy(g_state.snapshot_dir, config->snapshot_dir, dir_len);
+    g_state.snapshot_dir[dir_len] = '\0';
+    if (snprintf(g_state.base_snapshot_path,
+                 sizeof(g_state.base_snapshot_path),
+                 "%s/%s",
+                 g_state.snapshot_dir,
+                 BASE_SNAPSHOT_NAME) >= (int)sizeof(g_state.base_snapshot_path)) {
+        fkv_persistence_disable();
+        errno = ENAMETOOLONG;
+        return -1;
+    }
+    g_state.snapshot_interval = config->snapshot_interval ? config->snapshot_interval : 64;
+    g_state.wal_ops_since_checkpoint = 0;
+    g_state.next_delta_seq = 0;
+    return 0;
+}
+
+void fkv_persistence_disable(void) {
+    if (g_state.wal_fp) {
+        fclose(g_state.wal_fp);
+    }
+    memset(&g_state, 0, sizeof(g_state));
+}
+
+bool fkv_persistence_enabled(void) {
+    return g_state.enabled;
+}
+
+int fkv_persistence_start(fkv_persistence_apply_fn apply, void *userdata) {
+    if (!g_state.enabled) {
+        return 0;
+    }
+    if (!apply) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (ensure_parent_dir(g_state.wal_path) != 0) {
+        return -1;
+    }
+    if (ensure_dir_recursive(g_state.snapshot_dir) != 0) {
+        return -1;
+    }
+    fkv_delta_file_t *delta_files = NULL;
+    size_t delta_count = 0;
+    if (collect_delta_files(&delta_files, &delta_count) != 0) {
+        return -1;
+    }
+    if (open_wal() != 0) {
+        free(delta_files);
+        return -1;
+    }
+    if (load_base_snapshot(apply, userdata) != 0) {
+        free(delta_files);
+        fkv_persistence_shutdown();
+        return -1;
+    }
+    if (apply_delta_files(delta_files, delta_count, apply, userdata) != 0) {
+        free(delta_files);
+        fkv_persistence_shutdown();
+        return -1;
+    }
+    free(delta_files);
+    if (apply_wal(apply, userdata) != 0) {
+        fkv_persistence_shutdown();
+        return -1;
+    }
+    if (fseek(g_state.wal_fp, 0, SEEK_END) != 0) {
+        fkv_persistence_shutdown();
+        return -1;
+    }
+    return 0;
+}
+
+int fkv_persistence_record_put(const uint8_t *key,
+                               size_t key_len,
+                               const uint8_t *value,
+                               size_t value_len,
+                               fkv_entry_type_t type) {
+    if (!g_state.enabled) {
+        return 0;
+    }
+    if (!g_state.wal_fp && open_wal() != 0) {
+        return -1;
+    }
+    if (fseek(g_state.wal_fp, 0, SEEK_END) != 0) {
+        return -1;
+    }
+    uint8_t opcode = WAL_OP_PUT;
+    uint8_t type_byte = (uint8_t)type;
+    uint64_t klen = key_len;
+    uint64_t vlen = value_len;
+    if (fwrite(&opcode, 1, 1, g_state.wal_fp) != 1 ||
+        fwrite(&type_byte, 1, 1, g_state.wal_fp) != 1 ||
+        fwrite(&klen, sizeof(klen), 1, g_state.wal_fp) != 1) {
+        return -1;
+    }
+    if (klen > 0 && fwrite(key, 1, (size_t)klen, g_state.wal_fp) != (size_t)klen) {
+        return -1;
+    }
+    if (fwrite(&vlen, sizeof(vlen), 1, g_state.wal_fp) != 1) {
+        return -1;
+    }
+    if (vlen > 0 && fwrite(value, 1, (size_t)vlen, g_state.wal_fp) != (size_t)vlen) {
+        return -1;
+    }
+    if (fflush(g_state.wal_fp) != 0) {
+        return -1;
+    }
+    g_state.wal_ops_since_checkpoint += 1;
+    if (g_state.snapshot_interval > 0 &&
+        g_state.wal_ops_since_checkpoint >= g_state.snapshot_interval) {
+        return fkv_persistence_force_checkpoint();
+    }
+    return 0;
+}
+
+void fkv_persistence_shutdown(void) {
+    if (g_state.wal_fp) {
+        fflush(g_state.wal_fp);
+        fclose(g_state.wal_fp);
+        g_state.wal_fp = NULL;
+    }
+}
+
+const char *fkv_persistence_wal_path(void) {
+    return g_state.enabled && g_state.wal_path[0] ? g_state.wal_path : NULL;
+}
+
+const char *fkv_persistence_base_snapshot_path(void) {
+    return g_state.enabled && g_state.base_snapshot_path[0] ? g_state.base_snapshot_path : NULL;
+}

--- a/src/fkv/replication.c
+++ b/src/fkv/replication.c
@@ -1,0 +1,197 @@
+#include "fkv/replication.h"
+
+#include "fkv/fkv.h"
+
+#include <errno.h>
+#include <limits.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <zlib.h>
+
+int fkv_replication_build_delta(const uint8_t *prefix_digits,
+                                size_t prefix_len,
+                                SwarmFrame *frame) {
+    if (!frame) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (prefix_len > (SWARM_PREFIX_DIGITS - 2)) {
+        errno = EINVAL;
+        return -1;
+    }
+    memset(frame, 0, sizeof(*frame));
+    frame->type = SWARM_FRAME_FKV_DELTA;
+    if (swarm_fkv_prefix_encode(prefix_digits, prefix_len, frame->payload.fkv_delta.prefix) != 0) {
+        errno = EINVAL;
+        return -1;
+    }
+    uint8_t prefix_buf[SWARM_PREFIX_DIGITS];
+    if (prefix_len > 0 && prefix_digits) {
+        memcpy(prefix_buf, prefix_digits, prefix_len);
+    }
+    fkv_iter_t it = {0};
+    if (fkv_get_prefix(prefix_len > 0 ? prefix_buf : NULL, prefix_len, &it, 0) != 0) {
+        return -1;
+    }
+    size_t raw_size = 0;
+    for (size_t i = 0; i < it.count; ++i) {
+        raw_size += 1 + 1 + sizeof(uint64_t) + sizeof(uint64_t);
+        raw_size += it.entries[i].key_len;
+        raw_size += it.entries[i].value_len;
+    }
+    uint8_t *raw = NULL;
+    if (raw_size > 0) {
+        raw = malloc(raw_size);
+        if (!raw) {
+            fkv_iter_free(&it);
+            return -1;
+        }
+        size_t offset = 0;
+        for (size_t i = 0; i < it.count; ++i) {
+            raw[offset++] = 1; /* WAL_OP_PUT */
+            raw[offset++] = (uint8_t)it.entries[i].type;
+            uint64_t key_len = (uint64_t)it.entries[i].key_len;
+            memcpy(raw + offset, &key_len, sizeof(uint64_t));
+            offset += sizeof(uint64_t);
+            if (key_len > 0) {
+                memcpy(raw + offset, it.entries[i].key, it.entries[i].key_len);
+                offset += it.entries[i].key_len;
+            }
+            uint64_t value_len = (uint64_t)it.entries[i].value_len;
+            memcpy(raw + offset, &value_len, sizeof(uint64_t));
+            offset += sizeof(uint64_t);
+            if (value_len > 0) {
+                memcpy(raw + offset, it.entries[i].value, it.entries[i].value_len);
+                offset += it.entries[i].value_len;
+            }
+        }
+    }
+    if (raw_size > UINT32_MAX) {
+        free(raw);
+        fkv_iter_free(&it);
+        errno = EOVERFLOW;
+        return -1;
+    }
+    frame->payload.fkv_delta.entry_count = (uint16_t)it.count;
+    frame->payload.fkv_delta.raw_size = (uint32_t)raw_size;
+    uint16_t checksum = swarm_crc16(raw, raw_size);
+    frame->payload.fkv_delta.checksum = checksum;
+    fkv_iter_free(&it);
+    if (raw_size == 0) {
+        frame->payload.fkv_delta.compressed_size = 0;
+        frame->payload.fkv_delta.data = NULL;
+        frame->payload.fkv_delta.data_len = 0;
+        return 0;
+    }
+    uLongf dest_capacity = compressBound(raw_size);
+    uint8_t *compressed = malloc(dest_capacity);
+    if (!compressed) {
+        free(raw);
+        return -1;
+    }
+    uLongf compressed_len = dest_capacity;
+    if (compress2(compressed, &compressed_len, raw, raw_size, Z_BEST_SPEED) != Z_OK) {
+        free(raw);
+        free(compressed);
+        return -1;
+    }
+    free(raw);
+    if (compressed_len > UINT32_MAX) {
+        free(compressed);
+        errno = EOVERFLOW;
+        return -1;
+    }
+    frame->payload.fkv_delta.compressed_size = (uint32_t)compressed_len;
+    frame->payload.fkv_delta.data = compressed;
+    frame->payload.fkv_delta.data_len = (size_t)compressed_len;
+    return 0;
+}
+
+int fkv_replication_apply_delta(const SwarmFrame *frame) {
+    if (!frame || frame->type != SWARM_FRAME_FKV_DELTA) {
+        errno = EINVAL;
+        return -1;
+    }
+    const SwarmFkvDeltaPayload *delta = &frame->payload.fkv_delta;
+    if (delta->compressed_size != (uint32_t)delta->data_len) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (delta->raw_size == 0) {
+        return 0;
+    }
+    if (!delta->data) {
+        errno = EINVAL;
+        return -1;
+    }
+    uint8_t *raw = malloc(delta->raw_size);
+    if (!raw) {
+        return -1;
+    }
+    uLongf raw_len = delta->raw_size;
+    if (uncompress(raw, &raw_len, delta->data, delta->data_len) != Z_OK || raw_len != delta->raw_size) {
+        free(raw);
+        errno = EINVAL;
+        return -1;
+    }
+    if (swarm_crc16(raw, raw_len) != delta->checksum) {
+        free(raw);
+        errno = EINVAL;
+        return -1;
+    }
+    size_t offset = 0;
+    while (offset < raw_len) {
+        if (raw_len - offset < 1 + 1 + sizeof(uint64_t) + sizeof(uint64_t)) {
+            free(raw);
+            errno = EINVAL;
+            return -1;
+        }
+        uint8_t opcode = raw[offset++];
+        if (opcode != 1) {
+            free(raw);
+            errno = EINVAL;
+            return -1;
+        }
+        uint8_t type = raw[offset++];
+        uint64_t key_len = 0;
+        memcpy(&key_len, raw + offset, sizeof(uint64_t));
+        offset += sizeof(uint64_t);
+        if (key_len > raw_len - offset) {
+            free(raw);
+            errno = EINVAL;
+            return -1;
+        }
+        const uint8_t *key = key_len ? raw + offset : NULL;
+        offset += (size_t)key_len;
+        uint64_t value_len = 0;
+        memcpy(&value_len, raw + offset, sizeof(uint64_t));
+        offset += sizeof(uint64_t);
+        if (value_len > raw_len - offset) {
+            free(raw);
+            errno = EINVAL;
+            return -1;
+        }
+        const uint8_t *value = value_len ? raw + offset : NULL;
+        offset += (size_t)value_len;
+        if (fkv_put(key, (size_t)key_len, value, (size_t)value_len, (fkv_entry_type_t)type) != 0) {
+            free(raw);
+            return -1;
+        }
+    }
+    free(raw);
+    return 0;
+}
+
+void fkv_replication_free_delta(SwarmFrame *frame) {
+    if (!frame || frame->type != SWARM_FRAME_FKV_DELTA) {
+        return;
+    }
+    free(frame->payload.fkv_delta.data);
+    frame->payload.fkv_delta.data = NULL;
+    frame->payload.fkv_delta.data_len = 0;
+    frame->payload.fkv_delta.compressed_size = 0;
+    frame->payload.fkv_delta.raw_size = 0;
+    frame->payload.fkv_delta.entry_count = 0;
+    frame->payload.fkv_delta.checksum = 0;
+}

--- a/src/formula_stub.c
+++ b/src/formula_stub.c
@@ -22,6 +22,18 @@ size_t formula_collection_get_top(const FormulaCollection *collection,
                                   const Formula **out_formulas,
                                   size_t max_results) WEAK_ATTR;
 
+static size_t formula_bounded_length(const char *src, size_t max_len) {
+    if (!src) {
+        return 0;
+    }
+
+    size_t len = 0;
+    while (len < max_len && src[len] != '\0') {
+        ++len;
+    }
+    return len;
+}
+
 static void formula_copy_string(char *dest, size_t dest_size, const char *src) {
     if (!dest || dest_size == 0) {
         return;
@@ -30,7 +42,7 @@ static void formula_copy_string(char *dest, size_t dest_size, const char *src) {
         dest[0] = '\0';
         return;
     }
-    size_t len = strnlen(src, dest_size - 1);
+    size_t len = formula_bounded_length(src, dest_size - 1);
     memcpy(dest, src, len);
     dest[len] = '\0';
 }

--- a/tests/integration/test_fkv_cluster.c
+++ b/tests/integration/test_fkv_cluster.c
@@ -1,0 +1,170 @@
+#include "fkv/fkv.h"
+#include "fkv/persistence.h"
+#include "fkv/replication.h"
+
+#include <assert.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+extern char *mkdtemp(char *);
+static void insert_sample(const char *key_str, const char *val_str, fkv_entry_type_t type) {
+    size_t klen = strlen(key_str);
+    size_t vlen = strlen(val_str);
+    uint8_t *kbuf = malloc(klen);
+    uint8_t *vbuf = malloc(vlen);
+    assert(kbuf && vbuf);
+    for (size_t i = 0; i < klen; ++i) {
+        kbuf[i] = (uint8_t)(key_str[i] - '0');
+    }
+    for (size_t i = 0; i < vlen; ++i) {
+        vbuf[i] = (uint8_t)(val_str[i] - '0');
+    }
+    assert(fkv_put(kbuf, klen, vbuf, vlen, type) == 0);
+    free(kbuf);
+    free(vbuf);
+}
+
+static void create_dir(char *buffer, size_t size, const char *tag) {
+    snprintf(buffer, size, "/tmp/%s_%ld_XXXXXX", tag, (long)getpid());
+    assert(mkdtemp(buffer) != NULL);
+}
+
+static void setup_config(const char *root_dir,
+                         char *wal_path,
+                         size_t wal_size,
+                         char *snapshot_dir,
+                         size_t snapshot_size,
+                         size_t interval) {
+    snprintf(wal_path, wal_size, "%s/wal.log", root_dir);
+    snprintf(snapshot_dir, snapshot_size, "%s/snapshots", root_dir);
+    if (mkdir(snapshot_dir, 0700) != 0 && errno != EEXIST) {
+        assert(0 && "mkdir failed");
+    }
+    fkv_persistence_config_t cfg = {
+        .wal_path = wal_path,
+        .snapshot_dir = snapshot_dir,
+        .snapshot_interval = interval,
+    };
+    assert(fkv_persistence_configure(&cfg) == 0);
+}
+
+static void cleanup_paths(const char *wal_path, const char *snapshot_dir, const char *root_dir) {
+    char delta_path[1024];
+    size_t suffix_needed = strlen("/delta_000000000000.fkz");
+    for (int i = 0; i < 4; ++i) {
+        size_t needed = strlen(snapshot_dir) + suffix_needed;
+        assert(needed < sizeof(delta_path));
+        snprintf(delta_path, sizeof(delta_path), "%s/delta_%012d.fkz", snapshot_dir, i);
+        unlink(delta_path);
+    }
+    unlink(wal_path);
+    char base_path[1024];
+    snprintf(base_path, sizeof(base_path), "%s/base.fkz", snapshot_dir);
+    unlink(base_path);
+    rmdir(snapshot_dir);
+    rmdir(root_dir);
+}
+
+static int has_entry(const fkv_iter_t *it, const char *key_str, const char *val_str) {
+    size_t klen = strlen(key_str);
+    size_t vlen = strlen(val_str);
+    for (size_t i = 0; i < it->count; ++i) {
+        const fkv_entry_t *entry = &it->entries[i];
+        if (entry->key_len != klen || entry->value_len != vlen) {
+            continue;
+        }
+        size_t matched = 1;
+        for (size_t j = 0; j < klen; ++j) {
+            if (entry->key[j] != (uint8_t)(key_str[j] - '0')) {
+                matched = 0;
+                break;
+            }
+        }
+        if (!matched) {
+            continue;
+        }
+        for (size_t j = 0; j < vlen; ++j) {
+            if (entry->value[j] != (uint8_t)(val_str[j] - '0')) {
+                matched = 0;
+                break;
+            }
+        }
+        if (matched) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+int main(void) {
+    char root_a[512];
+    char root_b[512];
+    create_dir(root_a, sizeof(root_a), "fkv_cluster_a");
+    create_dir(root_b, sizeof(root_b), "fkv_cluster_b");
+
+    char wal_a[1024];
+    char snap_a[1024];
+    setup_config(root_a, wal_a, sizeof(wal_a), snap_a, sizeof(snap_a), 2);
+
+    assert(fkv_init() == 0);
+    insert_sample("200", "01", FKV_ENTRY_TYPE_VALUE);
+    insert_sample("201", "02", FKV_ENTRY_TYPE_VALUE);
+    insert_sample("990", "77", FKV_ENTRY_TYPE_PROGRAM);
+
+    const char *base_a = fkv_persistence_base_snapshot_path();
+    char base_a_copy[512];
+    snprintf(base_a_copy, sizeof(base_a_copy), "%s", base_a);
+    assert(fkv_save(base_a_copy) == 0);
+    assert(fkv_persistence_force_checkpoint() == 0);
+
+    SwarmFrame delta_ab = {0};
+    assert(fkv_replication_build_delta(NULL, 0, &delta_ab) == 0);
+
+    fkv_shutdown();
+    fkv_persistence_disable();
+
+    char wal_b[1024];
+    char snap_b[1024];
+    setup_config(root_b, wal_b, sizeof(wal_b), snap_b, sizeof(snap_b), 2);
+    assert(fkv_init() == 0);
+    assert(fkv_replication_apply_delta(&delta_ab) == 0);
+    fkv_replication_free_delta(&delta_ab);
+
+    const char *base_b = fkv_persistence_base_snapshot_path();
+    char base_b_copy[512];
+    snprintf(base_b_copy, sizeof(base_b_copy), "%s", base_b);
+    assert(fkv_save(base_b_copy) == 0);
+    assert(fkv_persistence_force_checkpoint() == 0);
+
+    insert_sample("202", "03", FKV_ENTRY_TYPE_VALUE);
+    SwarmFrame delta_ba = {0};
+    assert(fkv_replication_build_delta(NULL, 0, &delta_ba) == 0);
+
+    fkv_shutdown();
+    fkv_persistence_disable();
+
+    setup_config(root_a, wal_a, sizeof(wal_a), snap_a, sizeof(snap_a), 2);
+    assert(fkv_init() == 0);
+    assert(fkv_replication_apply_delta(&delta_ba) == 0);
+    fkv_replication_free_delta(&delta_ba);
+
+    uint8_t prefix2[] = {2, 0};
+    fkv_iter_t it = {0};
+    assert(fkv_get_prefix(prefix2, sizeof(prefix2), &it, 0) == 0);
+    assert(has_entry(&it, "200", "01"));
+    assert(has_entry(&it, "202", "03"));
+    fkv_iter_free(&it);
+
+    fkv_shutdown();
+    fkv_persistence_disable();
+
+    cleanup_paths(wal_a, snap_a, root_a);
+    cleanup_paths(wal_b, snap_b, root_b);
+
+    printf("cluster replication test passed\n");
+    return 0;
+}

--- a/tests/unit/test_fkv.c
+++ b/tests/unit/test_fkv.c
@@ -1,6 +1,9 @@
 /* Copyright (c) 2024 Кочуров Владислав Евгеньевич */
 
 #include "fkv/fkv.h"
+#include "fkv/persistence.h"
+#include "fkv/replication.h"
+#include "protocol/swarm.h"
 
 #include <assert.h>
 #include <fcntl.h>
@@ -8,6 +11,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <sys/stat.h>
+
+extern char *mkdtemp(char *);
 
 static void insert_sample(const char *key_str, const char *val_str, fkv_entry_type_t type) {
     size_t klen = strlen(key_str);
@@ -25,12 +31,36 @@ static void insert_sample(const char *key_str, const char *val_str, fkv_entry_ty
     free(vbuf);
 }
 
+static int entry_matches(const fkv_entry_t *entry, const char *key_str, const char *val_str) {
+    size_t klen = strlen(key_str);
+    size_t vlen = strlen(val_str);
+    if (entry->key_len != klen || entry->value_len != vlen) {
+        return 0;
+    }
+    for (size_t i = 0; i < klen; ++i) {
+        if (entry->key[i] != (uint8_t)(key_str[i] - '0')) {
+            return 0;
+        }
+    }
+    for (size_t i = 0; i < vlen; ++i) {
+        if (entry->value[i] != (uint8_t)(val_str[i] - '0')) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
 static void create_temp_snapshot(char *buffer, size_t buffer_size, const char *tag) {
     static unsigned counter = 0;
     snprintf(buffer, buffer_size, "/tmp/%s_%ld_%u.snapshot", tag, (long)getpid(), counter++);
     int fd = open(buffer, O_CREAT | O_TRUNC | O_RDWR, 0600);
     assert(fd != -1);
     close(fd);
+}
+
+static void create_temp_dir(char *buffer, size_t buffer_size, const char *tag) {
+    snprintf(buffer, buffer_size, "/tmp/%s_%ld_XXXXXX", tag, (long)getpid());
+    assert(mkdtemp(buffer) != NULL);
 }
 
 static void test_prefix(void) {
@@ -117,10 +147,107 @@ static void test_load_overwrites_existing(void) {
     unlink(snapshot);
 }
 
+static void test_persistence_recovery(void) {
+    char root_dir[512];
+    create_temp_dir(root_dir, sizeof(root_dir), "fkv_persist_root");
+
+    char wal_path[1024];
+    char snapshot_dir[1024];
+    snprintf(wal_path, sizeof(wal_path), "%s/wal.log", root_dir);
+    snprintf(snapshot_dir, sizeof(snapshot_dir), "%s/snapshots", root_dir);
+    assert(mkdir(snapshot_dir, 0700) == 0);
+
+    fkv_persistence_config_t cfg = {
+        .wal_path = wal_path,
+        .snapshot_dir = snapshot_dir,
+        .snapshot_interval = 2,
+    };
+    assert(fkv_persistence_configure(&cfg) == 0);
+
+    assert(fkv_init() == 0);
+    insert_sample("120", "01", FKV_ENTRY_TYPE_VALUE);
+    insert_sample("121", "02", FKV_ENTRY_TYPE_VALUE);
+    insert_sample("980", "777", FKV_ENTRY_TYPE_PROGRAM);
+
+    const char *base_path = fkv_persistence_base_snapshot_path();
+    assert(base_path);
+    char base_copy[512];
+    snprintf(base_copy, sizeof(base_copy), "%s", base_path);
+    assert(fkv_save(base_copy) == 0);
+    assert(fkv_persistence_force_checkpoint() == 0);
+    fkv_shutdown();
+
+    assert(fkv_init() == 0);
+    uint8_t prefix12[] = {1, 2};
+    fkv_iter_t it = {0};
+    assert(fkv_get_prefix(prefix12, sizeof(prefix12), &it, 0) == 0);
+    assert(it.count >= 2);
+    int found120 = 0;
+    for (size_t i = 0; i < it.count; ++i) {
+        if (entry_matches(&it.entries[i], "120", "01")) {
+            found120 = 1;
+        }
+    }
+    assert(found120);
+    fkv_iter_free(&it);
+
+    uint8_t prefix98[] = {9, 8};
+    assert(fkv_get_prefix(prefix98, sizeof(prefix98), &it, 0) == 0);
+    assert(it.count == 1);
+    assert(it.entries[0].type == FKV_ENTRY_TYPE_PROGRAM);
+    fkv_iter_free(&it);
+
+    fkv_shutdown();
+    fkv_persistence_disable();
+
+    unlink(base_copy);
+    char delta_path[1024];
+    size_t required = strlen(snapshot_dir) + strlen("/delta_000000000000.fkz");
+    assert(required < sizeof(delta_path));
+    snprintf(delta_path, sizeof(delta_path), "%s/delta_%012d.fkz", snapshot_dir, 0);
+    unlink(delta_path);
+    unlink(wal_path);
+    rmdir(snapshot_dir);
+    rmdir(root_dir);
+}
+
+static void test_replication_delta_flow(void) {
+    assert(fkv_init() == 0);
+    insert_sample("120", "01", FKV_ENTRY_TYPE_VALUE);
+    insert_sample("121", "02", FKV_ENTRY_TYPE_VALUE);
+    insert_sample("129", "33", FKV_ENTRY_TYPE_PROGRAM);
+
+    uint8_t prefix[] = {1, 2};
+    SwarmFrame frame = {0};
+    assert(fkv_replication_build_delta(prefix, sizeof(prefix), &frame) == 0);
+    assert(frame.payload.fkv_delta.entry_count >= 2);
+
+    fkv_shutdown();
+    assert(fkv_init() == 0);
+    insert_sample("120", "99", FKV_ENTRY_TYPE_VALUE);
+
+    assert(fkv_replication_apply_delta(&frame) == 0);
+    fkv_replication_free_delta(&frame);
+
+    fkv_iter_t it = {0};
+    assert(fkv_get_prefix(prefix, sizeof(prefix), &it, 0) == 0);
+    int restored = 0;
+    for (size_t i = 0; i < it.count; ++i) {
+        if (entry_matches(&it.entries[i], "120", "01")) {
+            restored = 1;
+        }
+    }
+    assert(restored);
+    fkv_iter_free(&it);
+    fkv_shutdown();
+}
+
 int main(void) {
     test_prefix();
     test_serialization_roundtrip();
     test_load_overwrites_existing();
+    test_persistence_recovery();
+    test_replication_delta_flow();
     printf("fkv tests passed\n");
     return 0;
 }


### PR DESCRIPTION
## Summary
- implement write-ahead logging and compressed incremental snapshots for F-KV persistence
- add Swarm-compatible replication delta builder/apply helpers and expose new protocol utilities
- expand unit and integration coverage for persistence recovery, replication, and cluster consistency

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68d35e731e6083238f9804537b4b2d8b