### PR TITLE
Remove libuuid dependency from synthesis search

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ CC ?= gcc
 CFLAGS := -std=c11 -Wall -Wextra -O2 -Isrc -Iinclude -I/usr/include/json-c -pthread
 
 
-LDFLAGS := -lpthread -lm -luuid -lcrypto -lcurl
+LDFLAGS := -lpthread -lm -lcrypto -lcurl
 
 
 BUILD_DIR := build/obj
@@ -21,11 +21,9 @@ SRC := \
   src/http/http_server.c \
   src/http/http_routes.c \
   src/blockchain.c \
-
   src/formula_runtime.c \
   src/synthesis/search.c \
-  src/synthesis/formula_vm_eval.c
-
+  src/synthesis/formula_vm_eval.c \
   src/formula_stub.c \
   src/protocol/swarm.c
 


### PR DESCRIPTION
## Summary
- replace the UUID generation in the synthesis search module with an internal helper based on timestamps and an atomic counter
- drop the unused libuuid linker dependency and clean up the source list formatting in the Makefile

## Testing
- make build

------
https://chatgpt.com/codex/tasks/task_e_68d3655fd2dc83238ebca62c393f0138