### PR TITLE
Update benchmark artifact upload action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Run performance benchmarks
         run: ./kolibri.sh bench --output logs/ci_bench.json
       - name: Upload benchmark report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bench-report
           path: logs/ci_bench.json


### PR DESCRIPTION
## Summary
- update the benchmark artifact upload step to use actions/upload-artifact v4

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d3bf8ac86c832389208b0e86c301d7