### PR TITLE
Handle duplicate config keys gracefully

### DIFF
--- a/include/util/config.h
+++ b/include/util/config.h
@@ -48,8 +48,6 @@ typedef struct {
 
     ai_persistence_config_t ai;
     KolibriAISelfplayConfig selfplay;
-    FormulaSearchConfig search;
-    uint32_t seed;
 } kolibri_config_t;
 
 int config_load(const char *path, kolibri_config_t *cfg);

--- a/tests/unit/test_config.c
+++ b/tests/unit/test_config.c
@@ -36,14 +36,41 @@ static void test_config_valid(void) {
         "  // http configuration\n"
         "  \"http\": {\n"
         "    \"host\": \"127.0.0.1\",\n"
-        "    \"port\": 8080 /* comment */\n"
+        "    \"port\": 8080,\n"
+        "    \"port\": 9090, // duplicate should be ignored\n"
+        "    \"max_body_size\": 65536\n"
         "  },\n"
         "  \"vm\": {\n"
         "    \"max_steps\": 4096,\n"
         "    \"max_stack\": 256,\n"
-        "    \"trace_depth\": 32\n"
+        "    \"trace_depth\": 32,\n"
+        "    \"max_stack\": 1024 // duplicate ignored\n"
         "  },\n"
-        "  \"seed\": 777\n"
+        "  \"fkv\": {\n"
+        "    \"top_k\": 10,\n"
+        "    \"top_k\": 20\n"
+        "  },\n"
+        "  \"ai\": {\n"
+        "    \"snapshot_path\": \"data/custom_snapshot.json\",\n"
+        "    \"snapshot_path\": \"data/ignored.json\",\n"
+        "    \"snapshot_limit\": 4096\n"
+        "  },\n"
+        "  \"selfplay\": {\n"
+        "    \"tasks_per_iteration\": 16,\n"
+        "    \"tasks_per_iteration\": 32,\n"
+        "    \"max_difficulty\": 5\n"
+        "  },\n"
+        "  \"search\": {\n"
+        "    \"max_candidates\": 32,\n"
+        "    \"max_candidates\": 64,\n"
+        "    \"max_terms\": 12,\n"
+        "    \"max_coefficient\": 7,\n"
+        "    \"max_formula_length\": 48,\n"
+        "    \"base_effectiveness\": 0.75,\n"
+        "    \"base_effectiveness\": 0.1\n"
+        "  },\n"
+        "  \"seed\": 777,\n"
+        "  \"seed\": 555\n"
         "}\n";
 
     char *path = write_temp_file(content);
@@ -52,9 +79,20 @@ static void test_config_valid(void) {
     assert(config_load(path, &cfg) == 0);
     assert(strcmp(cfg.http.host, "127.0.0.1") == 0);
     assert(cfg.http.port == 8080);
+    assert(cfg.http.max_body_size == 65536);
     assert(cfg.vm.max_steps == 4096);
     assert(cfg.vm.max_stack == 256);
     assert(cfg.vm.trace_depth == 32);
+    assert(cfg.fkv.top_k == 10);
+    assert(strcmp(cfg.ai.snapshot_path, "data/custom_snapshot.json") == 0);
+    assert(cfg.ai.snapshot_limit == 4096);
+    assert(cfg.selfplay.tasks_per_iteration == 16);
+    assert(cfg.selfplay.max_difficulty == 5);
+    assert(cfg.search.max_candidates == 32);
+    assert(cfg.search.max_terms == 12);
+    assert(cfg.search.max_coefficient == 7);
+    assert(cfg.search.max_formula_length == 48);
+    assert(cfg.search.base_effectiveness == 0.75);
     assert(cfg.seed == 777);
     remove_temp_file(path);
 }


### PR DESCRIPTION
## Summary
- remove duplicate search/seed entries from `kolibri_config_t`
- make the JSON config parser skip duplicate keys while keeping the first value
- expand the config unit test to cover optional sections and duplicate handling

## Testing
- make test-config *(fails: Makefile:32: *** missing separator)*
- cc -std=c11 -Wall -Wextra -O2 -Isrc -Iinclude -pthread tests/unit/test_config.c src/util/config.c -o /tmp/test_config
- /tmp/test_config

------
https://chatgpt.com/codex/tasks/task_e_68d3bfd433748323a6030d0adb9a52f7