### PR TITLE
Streamline Makefile test orchestration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,6 @@
 
 CC ?= gcc
 
-CFLAGS ?= -std=c11 -Wall -Wextra -O2
-CFLAGS += -Isrc -Iinclude -pthread
-LDFLAGS ?=
-LDFLAGS += -lpthread -lm -luuid -lcrypto -lcurl 
-
 JSONC_CFLAGS := $(shell pkg-config --cflags json-c 2>/dev/null)
 JSONC_LIBS := $(shell pkg-config --libs json-c 2>/dev/null)
 
@@ -15,23 +10,20 @@ CFLAGS += -Isrc -Iinclude -pthread
 CFLAGS += $(JSONC_CFLAGS)
 CFLAGS += -I/usr/include/json-c
 
-
-LDFLAGS ?= -lpthread -lm -luuid -lcrypto -lcurl
+LDFLAGS ?=
+LDFLAGS += -lpthread -lm -luuid -lcrypto -lcurl
 LDFLAGS += $(JSONC_LIBS)
-LDFLAGS := -lpthread -lm -lcrypto -lcurl
-
-
-
 
 BUILD_DIR := build/obj
 BIN_DIR := bin
 TARGET := $(BIN_DIR)/kolibri_node
 
 SRC := \
-
     src/main.c \
     src/util/log.c \
+    src/util/bench.c \
     src/util/config.c \
+    src/util/json_compat.c \
     src/vm/vm.c \
     src/fkv/fkv.c \
     src/kolibri_ai.c \
@@ -44,37 +36,11 @@ SRC := \
     src/formula_stub.c \
     src/protocol/swarm.c
 
-  src/main.c \
-  src/util/log.c \
-  src/util/bench.c \
-  src/util/config.c \
-  src/util/json_compat.c \
-  src/vm/vm.c \
-  src/fkv/fkv.c \
-  src/kolibri_ai.c \
-  src/http/http_server.c \
-  src/http/http_routes.c \
-  src/blockchain.c \
-  src/formula_runtime.c \
-  src/synthesis/search.c \
-  src/synthesis/formula_vm_eval.c \
-  src/formula_stub.c \
-  src/protocol/swarm.c
-
-
 OBJ := $(SRC:src/%.c=$(BUILD_DIR)/%.o)
 
 TEST_VM_SRC := tests/unit/test_vm.c src/vm/vm.c src/util/log.c src/util/config.c src/fkv/fkv.c
 TEST_FKV_SRC := tests/unit/test_fkv.c src/fkv/fkv.c src/util/log.c src/util/config.c
 TEST_CONFIG_SRC := tests/unit/test_config.c src/util/config.c src/util/log.c
-
-TEST_KOLIBRI_ITER_SRC := tests/test_kolibri_ai_iterations.c src/kolibri_ai.c src/formula_runtime.c src/synthesis/search.c src/synthesis/formula_vm_eval.c src/vm/vm.c src/fkv/fkv.c src/util/log.c src/util/config.c
-TEST_SWARM_PROTOCOL_SRC := tests/unit/test_swarm_protocol.c src/protocol/swarm.c src/util/log.c src/util/config.c
-TEST_HTTP_ROUTES_SRC := tests/unit/test_http_routes.c src/http/http_routes.c src/blockchain.c src/formula_stub.c src/util/log.c src/util/config.c
-
-.PHONY: all build clean run test test-vm test-fkv test-config test-kolibri-ai test-swarm-protocol test-http-routes bench
-
-TEST_KOLIBRI_ITER_SRC := tests/test_kolibri_ai_iterations.c src/kolibri_ai.c src/formula_runtime.c src/synthesis/search.c src/synthesis/formula_vm_eval.c src/vm/vm.c src/fkv/fkv.c
 TEST_KOLIBRI_ITER_SRC := \
   tests/test_kolibri_ai_iterations.c \
   src/kolibri_ai.c \
@@ -87,9 +53,7 @@ TEST_KOLIBRI_ITER_SRC := \
   src/util/log.c \
   src/util/config.c \
   src/util/json_compat.c
-TEST_KOLIBRI_ITER_SRC := tests/test_kolibri_ai_iterations.c src/kolibri_ai.c src/formula_runtime.c src/synthesis/search.c src/synthesis/formula_vm_eval.c src/vm/vm.c src/fkv/fkv
-TEST_SWARM_PROTOCOL_SRC := tests/unit/test_swarm_protocol.c src/protocol/swarm.c
-TEST_HTTP_ROUTES_SRC := tests/unit/test_http_routes.c src/http/http_routes.c src/synthesis/formula_vm_eval.c src/vm/vm.c src/util/log.c src/util/config.c src/fkv/fkv.c src/kolibri_ai.c src/formula_runtime.c src/synthesis/search.c src/formula_stub.c
+TEST_SWARM_PROTOCOL_SRC := tests/unit/test_swarm_protocol.c src/protocol/swarm.c src/util/log.c src/util/config.c
 TEST_HTTP_ROUTES_SRC := \
   tests/unit/test_http_routes.c \
   src/http/http_routes.c \
@@ -101,12 +65,11 @@ TEST_HTTP_ROUTES_SRC := \
   src/formula_runtime.c \
   src/synthesis/formula_vm_eval.c \
   src/synthesis/search.c \
-  src/kolibri_ai.c
+  src/kolibri_ai.c \
+  src/formula_stub.c
+TEST_REGRESS_SRC := tests/test_blockchain_verifier.c src/blockchain.c src/formula_runtime.c src/formula_stub.c src/util/log.c
 
-
-
-OBJ := $(SRC:src/%.c=$(BUILD_DIR)/%.o)
-
+.PHONY: all build clean run test test-vm test-fkv test-config test-kolibri-ai test-swarm-protocol test-http-routes test-regress bench
 
 all: build
 
@@ -131,76 +94,58 @@ run: build
 clean:
 	rm -rf $(BUILD_DIR) $(BIN_DIR) logs/* data/* web/node_modules web/dist
 
-
-bench: build
-	$(TARGET) --bench
-
-.PHONY: test test-vm test-fkv test-config test-kolibri-ai test-swarm-protocol test-http-routes bench clean run build
-
-
-
-test: build test-vm test-fkv test-config test-kolibri-ai test-swarm-protocol test-http-routes
-
-
-test: build test-vm test-fkv test-config test-kolibri-ai test-swarm-protocol test-http-routes
-
 $(BUILD_DIR)/tests/unit/test_vm: $(TEST_VM_SRC)
 	@mkdir -p $(dir $@)
-	$(CC) $(CFLAGS) $(TEST_VM_SRC) -o $@ $(LDFLAGS)
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 
 test-vm: $(BUILD_DIR)/tests/unit/test_vm
 	$<
 
 $(BUILD_DIR)/tests/unit/test_fkv: $(TEST_FKV_SRC)
 	@mkdir -p $(dir $@)
-	$(CC) $(CFLAGS) $(TEST_FKV_SRC) -o $@ $(LDFLAGS)
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 
 test-fkv: $(BUILD_DIR)/tests/unit/test_fkv
 	$<
 
 $(BUILD_DIR)/tests/unit/test_config: $(TEST_CONFIG_SRC)
 	@mkdir -p $(dir $@)
-	$(CC) $(CFLAGS) $(TEST_CONFIG_SRC) -o $@ $(LDFLAGS)
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 
 test-config: $(BUILD_DIR)/tests/unit/test_config
 	$<
 
 $(BUILD_DIR)/tests/test_kolibri_ai_iterations: $(TEST_KOLIBRI_ITER_SRC)
 	@mkdir -p $(dir $@)
-	$(CC) $(CFLAGS) $(TEST_KOLIBRI_ITER_SRC) -o $@ $(LDFLAGS)
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 
 test-kolibri-ai: $(BUILD_DIR)/tests/test_kolibri_ai_iterations
 	$<
 
 $(BUILD_DIR)/tests/unit/test_swarm_protocol: $(TEST_SWARM_PROTOCOL_SRC)
 	@mkdir -p $(dir $@)
-	$(CC) $(CFLAGS) $(TEST_SWARM_PROTOCOL_SRC) -o $@ $(LDFLAGS)
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 
 test-swarm-protocol: $(BUILD_DIR)/tests/unit/test_swarm_protocol
-        $<
-
-$(BUILD_DIR)/tests/unit/test_http_routes: $(TEST_HTTP_ROUTES_SRC)
-	@mkdir -p $(BUILD_DIR)/tests/unit
-	$(CC) $(CFLAGS) $(TEST_HTTP_ROUTES_SRC) -o $@ $(LDFLAGS)
-
-test-http-routes: $(BUILD_DIR)/tests/unit/test_http_routes
 	$<
-
-$(BUILD_DIR)/tests/unit/test_http_routes: $(TEST_HTTP_ROUTES_SRC)
-	@mkdir -p $(BUILD_DIR)/tests/unit
-	$(CC) $(CFLAGS) $(TEST_HTTP_ROUTES_SRC) -o $@ $(LDFLAGS)
-
-test-http-routes: $(BUILD_DIR)/tests/unit/test_http_routes
-	$<
-
 
 $(BUILD_DIR)/tests/unit/test_http_routes: $(TEST_HTTP_ROUTES_SRC)
 	@mkdir -p $(dir $@)
-	$(CC) $(CFLAGS) $(TEST_HTTP_ROUTES_SRC) -o $@ $(LDFLAGS)
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 
 test-http-routes: $(BUILD_DIR)/tests/unit/test_http_routes
 	$<
+
+$(BUILD_DIR)/tests/test_blockchain_verifier: $(TEST_REGRESS_SRC)
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+
+test-regress: $(BUILD_DIR)/tests/test_blockchain_verifier
+	$<
+
+BENCH_ARGS ?=
 
 bench: build
 	$(TARGET) --bench $(BENCH_ARGS)
 
+test: build test-vm test-fkv test-config test-kolibri-ai test-swarm-protocol test-http-routes test-regress


### PR DESCRIPTION
## Summary
- keep JSON-C and uuid linker flags by switching the last LDFLAGS assignment to an additive update
- collapse duplicated TEST_* source definitions and add missing dependencies for kolibri iteration and HTTP route tests
- ensure test targets are defined once and extend `make test` with the blockchain regression suite

## Testing
- `make test` *(fails: existing compile errors in include/util/config.h and several C sources)*

------
https://chatgpt.com/codex/tasks/task_e_68d3bfd193548323a840cd914121c699