### PR TITLE
fix: deduplicate formula collection helpers

### DIFF
--- a/include/formula.h
+++ b/include/formula.h
@@ -26,6 +26,9 @@ Formula* formula_collection_find(FormulaCollection* collection, const char* id);
 size_t formula_collection_get_top(const FormulaCollection* collection,
                                   const Formula** out_formulas,
                                   size_t max_results);
+void formula_collection_reset_top(FormulaCollection* collection);
+void formula_collection_consider_index(FormulaCollection* collection, size_t index);
+void formula_collection_recompute_top(FormulaCollection* collection);
 
 // Text-based formula utilities.
 int get_formula_type(const char* content);

--- a/src/formula.c
+++ b/src/formula.c
@@ -23,7 +23,7 @@
 #define KOLIBRI_AI_LEARNING_DATA_DEFAULT "data/kolibri_ai_learning.jsonl"
 #endif
 
-static void formula_collection_reset_top(FormulaCollection* collection) {
+void formula_collection_reset_top(FormulaCollection* collection) {
     if (!collection) {
         return;
     }
@@ -33,7 +33,7 @@ static void formula_collection_reset_top(FormulaCollection* collection) {
     collection->best_count = 0;
 }
 
-static void formula_collection_consider_index(FormulaCollection* collection, size_t index) {
+void formula_collection_consider_index(FormulaCollection* collection, size_t index) {
     if (!collection || index >= collection->count) {
         return;
     }
@@ -75,7 +75,7 @@ static void formula_collection_consider_index(FormulaCollection* collection, siz
     }
 }
 
-static void formula_collection_recompute_top(FormulaCollection* collection) {
+void formula_collection_recompute_top(FormulaCollection* collection) {
     if (!collection) {
         return;
     }

--- a/src/formula_runtime.c
+++ b/src/formula_runtime.c
@@ -23,69 +23,6 @@ const int FORMULA_TYPE_POLYNOMIAL = 1;
 const int FORMULA_TYPE_COMPOSITE = 2;
 const int FORMULA_TYPE_PERIODIC = 3;
 
-static void formula_collection_reset_top(FormulaCollection *collection) {
-    if (!collection) {
-        return;
-    }
-
-    collection->best_indices[0] = SIZE_MAX;
-    collection->best_indices[1] = SIZE_MAX;
-    collection->best_count = 0;
-}
-
-static void formula_collection_consider_index(FormulaCollection *collection, size_t index) {
-    if (!collection || index >= collection->count) {
-        return;
-    }
-
-    const Formula *candidate = &collection->formulas[index];
-
-    if (collection->best_count == 0) {
-        collection->best_indices[0] = index;
-        collection->best_count = 1;
-        return;
-    }
-
-    size_t current_best = collection->best_indices[0];
-    const Formula *best_formula = &collection->formulas[current_best];
-
-    if (candidate->effectiveness > best_formula->effectiveness) {
-        size_t previous_best = collection->best_indices[0];
-        collection->best_indices[0] = index;
-        if (collection->best_count == 1) {
-            collection->best_indices[1] = previous_best;
-            collection->best_count = 2;
-        } else {
-            collection->best_indices[1] = previous_best;
-        }
-        return;
-    }
-
-    if (collection->best_count == 1) {
-        collection->best_indices[1] = index;
-        collection->best_count = 2;
-        return;
-    }
-
-    size_t current_second = collection->best_indices[1];
-    const Formula *second_formula = &collection->formulas[current_second];
-
-    if (candidate->effectiveness > second_formula->effectiveness) {
-        collection->best_indices[1] = index;
-    }
-}
-
-static void formula_collection_recompute_top(FormulaCollection *collection) {
-    if (!collection) {
-        return;
-    }
-
-    formula_collection_reset_top(collection);
-    for (size_t i = 0; i < collection->count; ++i) {
-        formula_collection_consider_index(collection, i);
-    }
-}
-
 void formula_clear(Formula *formula) {
     if (!formula) {
         return;


### PR DESCRIPTION
Fixes #0

## Summary
- expose the formula collection helper declarations in the public header so they can be reused
- provide a single implementation of the helper routines in src/formula.c and remove the duplicate copy from src/formula_runtime.c

## Testing
- clang-tidy src/formula.c -- -Iinclude -Isrc -std=c11
- clang-tidy src/formula_runtime.c -- -Iinclude -Isrc -std=c11
- make test *(fails: Makefile:24: *** recipe commences before first target.  Stop.)*
- make *(fails: Makefile:24: *** recipe commences before first target.  Stop.)*


------
https://chatgpt.com/codex/tasks/task_e_68d3f49854288323acc16f9d3ba3320b